### PR TITLE
Deployment size corrected

### DIFF
--- a/library/nsxt_deploy_ova.py
+++ b/library/nsxt_deploy_ova.py
@@ -281,11 +281,13 @@ def main():
         ovf_base_options.extend(['--net:Network 0={}'.format(module.params['portgroup']),
                                  '--net:Network 1={}'.format(module.params['portgroup_ext']),
                                  '--net:Network 2={}'.format(module.params['portgroup_transport']),
-                                 '--net:Network 3={}'.format(module.params['portgroup']),
-                                 '--deploymentOption={}'.format(module.params['deployment_size'])])
+                                 '--net:Network 3={}'.format(module.params['portgroup'])])
     else:
         ovf_base_options.extend(['--network={}'.format(module.params['portgroup'])])
     ovf_command.extend(ovf_base_options)
+
+    ovf_deployement_size = ['--deploymentOption={}'.format(module.params['deployment_size'])]
+    ovf_command.extend(ovf_deployement_size)
 
     ovf_ext_prop = ['--prop:nsx_hostname={}'.format(module.params['hostname']),
                    '--prop:nsx_dns1_0={}'.format(module.params['dns_server']),


### PR DESCRIPTION
Deployment size was not getting initialized as
per user needs. The issue is corrected now.

Problem: Deployment size was having port group
dependency on it. It port group was not being
mentioned explicitly then the deployment size was set to medium by default.

Signed-off-by: Kommireddy Akhilesh akhileshk@vmware.com