### PR TITLE
nsxt_transport_nodes example correction

### DIFF
--- a/library/nsxt_transport_nodes.py
+++ b/library/nsxt_transport_nodes.py
@@ -399,9 +399,7 @@ EXAMPLES = '''
     username: "admin"
     password: "Admin!23Admin"
     validate_certs: False
-    resource_type: "TransportNode"
     display_name: "NSX Configured TN"
-    description: "NSX configured Test Transport Node"
     host_switch_spec:
       resource_type: "StandardHostSwitchSpec"
       host_switches:


### PR DESCRIPTION
nsxt_transport_node contained two extra lines in its example. The
lines caused the example to break when run as playbook. The error
is corrected now. This solves bug #56.

Signed-off-by: Akhilesh Kommireddy <akhileshk@vmware.com>