### PR TITLE
Bug insecure ssl connection

### DIFF
--- a/library/nsxt_deploy_ova.py
+++ b/library/nsxt_deploy_ova.py
@@ -212,8 +212,8 @@ def connect_to_api(vchost, vc_user, vc_pwd):
         service_instance = SmartConnect(host=vchost, user=vc_user, pwd=vc_pwd)
     except (requests.ConnectionError, ssl.SSLError):
         try:
-            context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-            context.verify_mode = ssl.CERT_NONE
+            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+            context.load_default_certs()
             service_instance = SmartConnect(host=vchost, user=vc_user, pwd=vc_pwd, sslContext=context)
         except Exception as e:
             raise Exception(e)


### PR DESCRIPTION
The connection was insecure. We were using 
SSL version sslv23 and verify mode CERT_NONE.
This would cause the connection to go through
even if vCenter doesn't provide a valid certificate.
The bug is solved now. The SSL version has been
updated to TLSv1.2 and the default server certificate
is being loaded now.

Signed-off-by: Kommireddy Akhilesh <akhileshk@vmware.com>