### PR TITLE
Added certificate based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,14 @@ These modules support ansible version 2.7 and onwards.
 
 # Build & Run
 
-Install PyVmOmi
+### Install PyVmOmi
 ```
 pip install --upgrade pyvmomi pyvim requests ssl
 ```
-Download and Install Ovf tool - [Ovftool](https://my.vmware.com/web/vmware/details?downloadGroup=OVFTOOL400&productId=353)
+### Download and Install Ovf tool 4.3 - [Ovftool](https://my.vmware.com/web/vmware/details?downloadGroup=OVFTOOL430&productId=742)
+(Note: Using ovftool version 4.0/4.1 causes OVA/OVF deployment failure with Error: cURL error: SSL connect error\nCompleted with errors\n)
 
-Download [ansible-for-nsxt](https://github.com/vmware/ansible-for-nsxt/archive/master.zip).
+### Download [ansible-for-nsxt](https://github.com/vmware/ansible-for-nsxt/archive/master.zip).
 ```
 unzip ansible-for-nsxt-master.zip
 cd ansible-for-nsxt-master
@@ -89,6 +90,38 @@ Edit test_basic_topology.yml and answerfile.yml to match values to your environm
 ```
 ansible-playbook test_basic_topology.yml -vvv
 ```
+
+### Authentication
+Ansible-for-nsxt supports two types of authentication. They are: 
+* Basic server authentication
+* Client based authentication
+
+#### Basic server authentication
+In basic server authentication client has to explicitly provide NSX username and password to the NSX manager. The credentials have to be listed in ansible-playbook i.e. *.yml files.
+
+#### Client based authentication
+In this case clients have to register their certificates to NSX manager. After registering the certificates, client has to create its own principal identity on NSX manager.
+The process of certificate registration and creation of principal identity has to be donw using basic server authentication. Edit test_certificates.yml and test_principal_identities.yml to match the values according to the client's environment.
+```
+ansible-playbook test_certificates.yml -vvv
+ansible-playbook test_principal_identities -vvv
+```
+The path of the .p12 file i.e the file containing public and private key has to be set to an environment variable named NSX_MANAGER_CERT_PATH. 
+**Note:** MAke sure NSX_MANAGER_CERT_PATH is set in the same environment, where the module is being executed.
+
+##### Generating certificates?
+Following commands can be used in order to generate certificates.
+```
+openssl req -newkey rsa:2048 -nodes -keyout nsx_certificate.key -x509 -days 365 -out nsx_certificate.crt -subj "/C=US/ST=California/L=Palo Alto/O=VMware/CN=certauth-test" -sha256
+
+openssl pkcs12 -export -out nsx_certificate.pfx -inkey nsx_certificate.key -in nsx_certificate.crt
+
+openssl pkcs12 -in nsx_certificate.pfx -out nsx_certificate.p12 -nodes
+```
+
+The nsx_certificate.crt file generated as output from the above command contains the public key certificate.
+the file nsx_certificate.p12 file contains the public and private key generated. The path of nsx_certificate.p12 file has to be set in the environment variable NSX_MANAGER_CERT_PATH.
+
 # Interoperability
 
 The following versions of NSX are supported:

--- a/answerfile.yml
+++ b/answerfile.yml
@@ -1,4 +1,4 @@
-hostname: "10.161.157.200"
+hostname: "10.108.71.201"
 username: "admin"
 password: "Admin!23Admin"
 validate_certs: False

--- a/library/nsxt_certificates.py
+++ b/library/nsxt_certificates.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 VMware, Inc.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: nsxt_certificates
+short_description: 'Add a New Certificate'
+description: "Adds a new private-public certificate or a chain of certificates (CAs) and, 
+              optionally, a private key that can be applied to one of the user-facing 
+              components (appliance management or edge). The certificate and the key 
+              should be stored in PEM format. If no private key is provided, the 
+              certificate is used as a client certificate in the trust store."
+version_added: '2.7'
+author: 'Kommireddy Akhilesh'
+options:
+    hostname:
+        description: 'Deployed NSX manager hostname.'
+        required: true
+        type: str
+    username:
+        description: 'The username to authenticate with the NSX manager.'
+        required: true
+        type: str
+    password:
+        description: 'The password to authenticate with the NSX manager.'
+        required: true
+        type: str
+    display_name:
+        description:'Identifier to use when displaying entity in logs or GUI'
+        required: true
+        type: str
+    pem_encoded_file:
+        description: 'File containing pem encoded certificate data'
+        required: true
+        type='str' 
+    private_key_file:
+        description: 'File containing private key data'
+        required: false
+        type: str
+    passphrase:
+        description: 'Password for private key encryption'
+        required: false
+        type: str
+    description:
+        description: 'Description of this resource'
+        required: false
+        type: str
+    id:
+        description: 'Unique identifier of this resource'
+        required: false
+        type: str
+    key_algo:
+        description: 'Key algorithm contained in this certificate'
+        required: false
+        type: str
+    resource_type:
+        description: 'Must be set to the value TrustObjectData'
+        required: false
+        type: str
+    state:
+        choices:
+            - present
+            - absent
+        description: "State can be either 'present' or 'absent'.
+                      'present' is used to create or update resource.
+                      'absent' is used to delete resource."
+        required: true
+
+'''
+
+EXAMPLES = '''
+- hosts: 127.0.0.1
+  connection: local
+  become: yes
+  vars_files:
+    - answerfile.yml
+  tasks:
+    - name: Add a new certificate
+      nsxt_certificates:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "Certificate_file"
+        pem_encoded_file: "/Path/to/crt/file"
+        passphrase: "paraphrase"
+        state: "present"
+'''
+
+RETURN = '''# '''
+
+import json, time
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request, get_certificate_string, get_private_key_string
+from ansible.module_utils._text import to_native
+
+def update_params_with_pem_encoding(certificate_params):
+    '''
+    params: Parameters passed to the certificate
+    result: Updated parameters. Files are replaced with the public and private strings. 
+    '''
+    certificate_params['pem_encoded'] = get_certificate_string (certificate_params.pop('pem_encoded_file', None))
+    if certificate_params.get('private_key_file') is not None:
+        certificate_params['private_key'] = get_private_key_string (certificate_params.pop('private_key_file', None))
+    return certificate_params
+
+def get_certificate_params(args=None):
+    args_to_remove = ['state', 'username', 'password', 'port', 'hostname', 'validate_certs']
+    for key in args_to_remove:
+        args.pop(key, None)
+    for key, value in args.copy().items():
+        if value == None:
+            args.pop(key, None)
+    return args
+
+def get_certificates(module, manager_url, mgr_username, mgr_password, validate_certs):
+  try:
+    (rc, resp) = request(manager_url+ '/trust-management/certificates', headers=dict(Accept='application/json'),
+                      url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+  except Exception as err:
+    module.fail_json(msg='Error accessing trust management certificates. Error [%s]' % (to_native(err)))
+  return resp
+
+def get_certificate_with_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, display_name):
+  '''
+  result: returns the certificate object with the display name provided
+  '''
+  certificates = get_certificates(module, manager_url, mgr_username, mgr_password, validate_certs)
+  if certificates and certificates['result_count']>0:
+    for certificate in certificates['results']:
+      if certificate.__contains__('display_name') and certificate['display_name'] == display_name:
+        return certificate
+  return None
+
+def main():
+  argument_spec = dict()
+  argument_spec.update(hostname=dict(type='str', required=True),
+                       username=dict(type='str', required=True),
+                       password=dict(type='str', required=True, no_log=True),
+                       port=dict(type='int', default=443),
+                       validate_certs=dict(type='bool', requried=False, default=True),
+                       display_name=dict(required=True, type='str'),
+                       pem_encoded_file=dict(required=True, type='str', no_log=True), 
+                       private_key_file=dict(required=False, type='str', no_log=True),
+                       passphrase=dict(required=False, type='str', no_log=True),
+                       description=dict(required=False, type='str'),
+                       id=dict(required=False, type='str'),
+                       key_algo=dict(required=False, type='str'),
+                       resource_type=dict(required=False, type='str'),
+                    state=dict(required=True, choices=['present', 'absent']))
+  '''
+  Core function of the module reponsible for adding and deleting the certififcate.
+  '''
+
+  module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+  certificate_params = get_certificate_params(module.params.copy())
+  certificate_params = update_params_with_pem_encoding(certificate_params)
+  state = module.params['state']
+  mgr_hostname = module.params['hostname']
+  mgr_username = module.params['username']
+  mgr_password = module.params['password']
+  validate_certs = module.params['validate_certs']
+  display_name = module.params['display_name']
+
+  manager_url = 'https://{}/api/v1'.format(mgr_hostname)
+
+  headers = dict(Accept="application/json")
+  headers['Content-Type'] = 'application/json'
+  request_data = json.dumps(certificate_params)
+  certificate_with_display_name = get_certificate_with_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, display_name)
+
+
+  if state == 'present':
+    # add the certificate
+    if certificate_with_display_name:
+      module.fail_json(msg="Certificate with display name \'%s\' already exists." % display_name)  
+    try:
+      (rc, resp) = request(manager_url+ '/trust-management/certificates?action=import', data=request_data, headers=headers, method='POST',
+                              url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+    except Exception as err:
+      module.fail_json(msg="Failed to add certificate.\n Error: [%s].\n Request_body[%s]." % (to_native(err), request_data))
+
+    time.sleep(5)
+    module.exit_json(changed=True, result=resp, message="certificate created. Response: [%s]" % str(resp))
+
+  elif state == 'absent': 
+    #Delete the certificate   
+    if not certificate_with_display_name:
+      module.fail_json(msg="Certificate with display name \'%s\' doesn't exists." % display_name)
+    certificate_id = certificate_with_display_name['id']
+    try:
+       (rc, resp) = request(manager_url+ '/trust-management/certificates/' + certificate_id, method='DELETE',
+                            url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+    except Exception as err:
+      module.fail_json(msg="Failed to delete certificate with display name \'%s\'. Error[%s]." % (display_name, to_native(err)))
+
+    time.sleep(5)
+    module.exit_json(changed=True, object_name=certificate_id, message="Certificate with certificate id: %s deleted." % certificate_id)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/nsxt_principal_identities.py
+++ b/library/nsxt_principal_identities.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 VMware, Inc.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: nsxt_principal_identities
+short_description: 'Register a name-certificate combination.'
+description: "Associates a principal's name with a certificate that is used to authenticate. "
+version_added: '2.7'
+author: 'Kommireddy Akhilesh'
+options:
+    hostname:
+        description: 'Deployed NSX manager hostname.'
+        required: true
+        type: str
+    username:
+        description: 'The username to authenticate with the NSX manager.'
+        required: true
+        type: str
+    password:
+        description: 'The password to authenticate with the NSX manager.'
+        required: true
+        type: str
+    display_name:
+        description: 'Identifier to use when displaying entity in logs or GUI'
+        required: true
+        type: str
+    name:
+        description: 'Name of the principal'
+        required: true
+        type: str
+    node_id:
+        description: 'Unique node-id'
+        required: true
+        type: str
+    certificate_name:
+        description: 'Display name of the certificate attached'
+        required: true
+        type: str
+    role:
+        description: 'Role'
+        required: true
+        type: str
+    description:
+        description: 'Description of this resource'
+        required: false
+        type: str
+    resource_type:
+        description: 'Must be set to the value PrincipalIdentity'
+        required: false
+        type: str
+    id:
+        description: 'Unique identifier of this resource'
+        required: false
+        type: str
+    is_protected:
+        description: 'Description of this resource'
+        required: false
+        type: bool
+    state:
+        choices:
+            - present
+            - absent
+        description: "State can be either 'present' or 'absent'.
+                      'present' is used to create or update resource.
+                      'absent' is used to delete resource."
+        required: true
+'''
+
+EXAMPLES = '''
+- hosts: 127.0.0.1
+  connection: local
+  become: yes
+  vars_files:
+    - answerfile.yml
+  tasks:
+    - name: Register a name-certificate combination
+      nsxt_principal_identities:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "Akhilesh_principal_display_name"
+        name: "Akhilesh_principal_name"
+        node_id: "node-1"
+        role: "enterprise_admin"
+        certificate_name: "Akhilesh_cert"
+        state: "present"
+'''
+
+RETURN = '''# '''
+
+import json, time
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request
+from ansible.module_utils._text import to_native
+
+def get_principal_identity_params(args=None):
+    args_to_remove = ['state', 'username', 'password', 'port', 'hostname', 'validate_certs']
+    for key in args_to_remove:
+        args.pop(key, None)
+    for key, value in args.copy().items():
+        if value == None:
+            args.pop(key, None)
+    return args
+
+def update_params_with_id (module, manager_url, mgr_username, mgr_password, validate_certs, principal_id_params ):
+    principal_id_params['certificate_id'] = get_id_from_display_name (module, manager_url, mgr_username, mgr_password, validate_certs,
+                                            '/trust-management/certificates', principal_id_params.pop('certificate_name', None))
+    return principal_id_params
+
+def get_id_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, endpoint, display_name):
+  try:
+    (rc, resp) = request(manager_url+ endpoint, headers=dict(Accept='application/json'),
+                      url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+  except Exception as err:
+    module.fail_json(msg='Error accessing id for display name %s. Error [%s]' % (display_name, to_native(err)))
+
+  for result in resp['results']:
+    if result.__contains__('display_name') and result['display_name'] == display_name:
+      return result['id']
+  module.fail_json(msg='No id exists with display name %s' % display_name)
+
+def get_principal_ids(module, manager_url, mgr_username, mgr_password, validate_certs):
+  try:
+    (rc, resp) = request(manager_url+ '/trust-management/principal-identities', headers=dict(Accept='application/json'),
+                      url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+  except Exception as err:
+    module.fail_json(msg='Error accessing principal identities. Error [%s]' % (to_native(err)))
+  return resp
+
+def get_principal_id_with_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, display_name):
+  '''
+  result: returns the principal id of the display name provided
+  '''
+  principal_ids = get_principal_ids(module, manager_url, mgr_username, mgr_password, validate_certs)
+  if principal_ids and len(principal_ids['results'])>0:
+    for principal_id in principal_ids['results']:
+      if principal_id.__contains__('display_name') and principal_id['display_name'] == display_name:
+        return principal_id
+  return None
+
+def main():
+  argument_spec = dict()
+  argument_spec.update(hostname=dict(type='str', required=True),
+                       username=dict(type='str', required=True),
+                       password=dict(type='str', required=True, no_log=True),
+                       port=dict(type='int', default=443),
+                       validate_certs=dict(type='bool', requried=False, default=True),
+                       display_name=dict(required=True, type='str'),
+                       name=dict(required=True, type='str'), 
+                       node_id=dict(required=True, type='str'),
+                       certificate_name=dict(required=True, type='str'),
+                       role=dict(required=True, type='str'),
+                       description=dict(required=False, type='str'),
+                       resource_type=dict(required=False, type='str'),
+                       id=dict(required=False, type='str'),
+                       is_protected=dict(required=False, type='bool'),
+                    state=dict(required=True, choices=['present', 'absent']))
+  '''
+  Core function of the module reponsible for adding and deleting the certififcate.
+  '''
+
+  module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+  principal_id_params = get_principal_identity_params(module.params.copy())
+  state = module.params['state']
+  mgr_hostname = module.params['hostname']
+  mgr_username = module.params['username']
+  mgr_password = module.params['password']
+  validate_certs = module.params['validate_certs']
+  display_name = module.params['display_name']
+
+  manager_url = 'https://{}/api/v1'.format(mgr_hostname)
+
+  headers = dict(Accept="application/json")
+  headers['Content-Type'] = 'application/json'
+  principal_id_params = update_params_with_id(module, manager_url, mgr_username, mgr_password, validate_certs, principal_id_params)
+  request_data = json.dumps(principal_id_params)
+  principal_id_with_display_name = get_principal_id_with_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, display_name)
+
+  if state == 'present':
+    # add the principal identity
+    if principal_id_with_display_name:
+      module.fail_json(msg="Principal id with display name \'%s\' already exists." % display_name)  
+    try:
+        (rc, resp) = request(manager_url+ '/trust-management/principal-identities', data=request_data, headers=headers, method='POST',
+                              url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+    except Exception as err:
+        module.fail_json(msg="Failed to add principal identity. Error[%s]. Request body [%s]." % (request_data, to_native(err)))
+
+    time.sleep(5)
+    module.exit_json(changed=True, result=resp, message="Principal identity created.")
+
+  elif state == 'absent':
+    # delete the principal identity
+    if not principal_id_with_display_name:
+      module.fail_json(msg="Principal identity with display name \'%s\' doesn't exists." % display_name)
+    principal_id = principal_id_with_display_name['id']
+    try:
+       (rc, resp) = request(manager_url+ '/trust-management/principal-identities/' + principal_id, method='DELETE',
+                            url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+    except Exception as err:
+      module.fail_json(msg="Failed to delete principal identity with display name \'%s\'. Error[%s]." % (display_name, to_native(err)))
+
+    time.sleep(5)
+    module.exit_json(changed=True, object_name=principal_id, message="Principal identity with display name \'%s\' and principal id \'%s\' deleted." %(display_name, principal_id))
+
+
+if __name__ == '__main__':
+    main()

--- a/module_utils/vmware_nsxt.py
+++ b/module_utils/vmware_nsxt.py
@@ -10,26 +10,40 @@
 # WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import json
+import json, os, re
 from ansible.module_utils.urls import open_url, fetch_url
 from ansible.module_utils.six.moves.urllib.error import HTTPError
+
 def vmware_argument_spec():
     return dict(
         hostname=dict(type='str', required=True),
-        username=dict(type='str', required=True),
-        password=dict(type='str', required=True, no_log=True),
+        username=dict(type='str', required=False),
+        password=dict(type='str', required=False, no_log=True),
         port=dict(type='int', default=443),
-        validate_certs=dict(type='bool', requried=False, default=True),
+        validate_certs=dict(type='bool', required=False, default=True),
     )
 
 def request(url, data=None, headers=None, method='GET', use_proxy=True,
             force=False, last_mod_time=None, timeout=300, validate_certs=True,
             url_username=None, url_password=None, http_agent=None, force_basic_auth=True, ignore_errors=False):
+    '''
+    The main function which hits the request to the manager. Username and password are given the topmost priority.
+    In case username and password are not provided if the environment variable is set.
+    Authentication fails if the details are not correct.
+    '''
+    if url_username is None or url_password is None:
+        force_basic_auth = False
+        client_cert = get_certificate_file_path('NSX_MANAGER_CERT_PATH')
+        if client_cert is None:
+            raise Exception("It seems that either you have not passed your username password correctly or your path for NSX_MANAGER_CERT_PATH is not set correctly.")
+    else:
+        client_cert = None
+
     try:
         r = open_url(url=url, data=data, headers=headers, method=method, use_proxy=use_proxy,
                      force=force, last_mod_time=last_mod_time, timeout=timeout, validate_certs=validate_certs,
                      url_username=url_username, url_password=url_password, http_agent=http_agent,
-                     force_basic_auth=force_basic_auth)
+                     client_cert=client_cert, force_basic_auth=force_basic_auth)
     except HTTPError as err:
         r = err.fp
 
@@ -53,3 +67,56 @@ def request(url, data=None, headers=None, method='GET', use_proxy=True,
         raise Exception (data['error_code'], data)
     else:
         return resp_code, data
+
+def get_certificate_string(crt_file):
+    '''
+    param: crt_file is the file containing the public key string
+    result: returns the public key(client certificate) string to be passed to the payload
+    how: String matching
+    '''
+    f = open(crt_file, 'r')
+    file_content = f.read()
+    file_content = file_content.split("\n")
+    certificate_string = ""
+    got_line_start = False
+    for string in file_content:
+        if string == "-----BEGIN CERTIFICATE-----":
+            got_line_start = True
+            certificate_string = certificate_string + string + "\n"
+        elif string == "-----END CERTIFICATE-----":
+            certificate_string = certificate_string + "\n" + string
+            break
+        elif got_line_start:
+            certificate_string = certificate_string + string
+        else:
+            pass
+    f.close()
+    return certificate_string
+
+def get_private_key_string(p12_file):
+    '''
+    param: p12_file is the file containing the private key string
+    result: returns the private key string to be passed to the payload
+    how: String matching
+    '''
+    f = open(p12_file, 'r')
+    file_content = f.read()
+    file_content = file_content.split("\n")
+    certificate_string = ""
+    got_start_line = False
+    for string in file_content:
+        if re.match("-+BEGIN[ \w]+PRIVATE[ ]+KEY-+", string):
+            got_start_line = True
+            certificate_string = certificate_string + string + "\n"
+        elif re.match("-+END[ \w]+PRIVATE[ ]+KEY-+", string):
+            certificate_string = certificate_string + "\n" + string
+            break
+        elif got_start_line:
+            certificate_string = certificate_string + string
+        else:
+            pass
+    f.close()
+    return certificate_string
+
+def get_certificate_file_path(environment_variable):
+    return os.getenv(environment_variable)

--- a/test_certificates.yml
+++ b/test_certificates.yml
@@ -1,0 +1,16 @@
+- hosts: 127.0.0.1
+  connection: local
+  become: yes
+  vars_files:
+    - answerfile.yml
+  tasks:
+    - name: Add a new certificate
+      nsxt_certificates:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "Certificate_file"
+        pem_encoded_file: "/Path/to/certificate/file"
+        #private_key_file: "/Path/to/p12/private/key/file"
+        state: "present"

--- a/test_principal_identities.yml
+++ b/test_principal_identities.yml
@@ -1,0 +1,18 @@
+- hosts: 127.0.0.1
+  connection: local
+  become: yes
+  vars_files:
+    - answerfile.yml
+  tasks:
+    - name: Register a name-certificate combination
+      nsxt_principal_identities:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "Principal_display_name"
+        name: "Principal_name"
+        node_id: "node-1"
+        role: "enterprise_admin"
+        certificate_name: "Certificate_file"
+        state: "present"


### PR DESCRIPTION
1. Now all clients can access API services using their self signed certificates.
2. The process of authentication and the creation
of the client certificates is mentioned in README.md file.
3. It is kept in mind that the previous method
of basic authentication works without any problem.

Signed-off-by: Kommireddy Akhilesh <akhileshk@vmware.com>