### PR TITLE
Add base py files for Policy API Ansible

### DIFF
--- a/policy-ansible-for-nsxt/module_utils/Logger.py
+++ b/policy-ansible-for-nsxt/module_utils/Logger.py
@@ -1,0 +1,23 @@
+class Logger(object):
+    __instance = None
+
+    def __init__(self):
+        self.logfile = '/root/vmware-ansible/ansible-for-nsxt/' + \
+            'policy-ansible-for-nsxt/logs/log'
+        if Logger.__instance is not None:
+            raise Exception("This class is a singleton!")
+        else:
+            Logger.__instance = self
+        with open(self.logfile, 'w+'):
+            pass
+
+    @staticmethod
+    def getInstance():
+        if Logger.__instance is None:
+            Logger()
+        return Logger.__instance
+
+    def log(self, data):
+        with open(self.logfile, 'a') as f:
+            f.write(data)
+            f.write('\n')

--- a/policy-ansible-for-nsxt/module_utils/NSXTAnsibleModule.py
+++ b/policy-ansible-for-nsxt/module_utils/NSXTAnsibleModule.py
@@ -1,0 +1,342 @@
+from ansible.module_utils.PolicyCommunicator import PolicyCommunicator
+from ansible.module_utils.PolicyCommunicator import DuplicateRequestError
+import ansible.module_utils.constants as constants
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+from abc import ABC, abstractmethod
+
+import time
+import json
+
+import inspect
+
+from ansible.module_utils.Logger import Logger
+logger = Logger.getInstance()
+
+
+class NSXTAnsibleResource(ABC):
+
+    INCORRECT_ARGUMENT_NAME_VALUE = "error_invalid_parameter"
+
+    def __init__(self, resource_arg_spec, resource_class,
+                 supports_check_mode=True):
+        resource_arg_spec.update(
+            # these are the base args for an NSXT Resource
+            id=dict(
+                required=True,
+                type='str'
+            ),
+            display_name=dict(
+                required=True,
+                type='str'
+            ),
+            tags=dict(
+                required=False,
+                type='dict',
+                scope=dict(
+                    required=False,
+                    type='str'
+                ),
+                tag=dict(
+                    required=False,
+                    type='str'
+                )
+            ),
+            state=dict(
+                required=True,
+                choices=['present', 'absent']
+            )
+        )
+        self.resource_class = resource_class
+        self.arg_spec = PolicyCommunicator.get_vmware_argument_spec()
+        self.resource_arg_spec = resource_arg_spec
+        self.arg_spec.update(resource_arg_spec)
+
+        self.module = AnsibleModule(argument_spec=self.arg_spec,
+                                    supports_check_mode=supports_check_mode)
+
+        mgr_hostname = self.module.params['hostname']
+        mgr_username = self.module.params['username']
+        mgr_password = self.module.params['password']
+
+        self.policy_communicator = PolicyCommunicator.get_instance(
+            mgr_username, mgr_hostname, mgr_password)
+
+        self.validate_certs = self.getAttribute('validate_certs')
+        self._state = self.getAttribute('state')
+        self.id = self.getAttribute('id')
+
+        self.resource_params = self._extract_resource_params(
+            self.module.params.copy())
+        try:
+            self.existing_resource = self._send_request_to_API(
+                "/" + self.id, ignore_error=False)
+            self._fill_missing_resource_params(
+                self.existing_resource, self.resource_params)
+        except Exception as err:
+            self.existing_resource = None
+
+    def getAttribute(self, attribute):
+        """
+            attribute: String
+
+            Returns the attribute from module params if specified.
+            - If it's a sub-resource, the param name must have its class name
+            as a prefix.
+            - The prefix is optional for base resource.
+        """
+        if self.get_resource_name() in constants.BASE_RESOURCES:
+            return self.module.params.get(
+                attribute, self.module.params.get(
+                    self.get_resource_name() + "_" + attribute,
+                    self.INCORRECT_ARGUMENT_NAME_VALUE))
+        else:
+            return self.module.params.get(
+                self.get_resource_name() + "_" + attribute,
+                self.INCORRECT_ARGUMENT_NAME_VALUE)
+
+    def _extract_resource_params(self, args=None,
+                                 unwanted_resource_params=set()):
+        # extract the params belonging to this resource only.
+        unwanted_resource_params.add("state")
+        params = {}
+        for key in self.resource_arg_spec.keys():
+            if key in self.module.params and \
+                key not in unwanted_resource_params and \
+                    self.module.params[key] is not None:
+                params[key] = self.module.params[key]
+        return params
+
+    def _send_request_to_API(self, suffix="", ignore_error=True,
+                             method='GET', data=None):
+        try:
+            (_, resp) = self.policy_communicator.request(
+                self.resource_class.get_resource_base_url()
+                + suffix, validate_certs=self.validate_certs,
+                ignore_errors=ignore_error, method=method, data=data)
+        except Exception as e:
+            raise e
+        return resp
+
+    @staticmethod
+    @abstractmethod
+    def get_resource_base_url():
+        # Must be overridden by the subclass
+        raise NotImplementedError
+
+    def get_resource_name(self):
+        return self.__class__.__name__
+
+    def _achieve_present_state(self, successful_resource_exec_logs):
+        logger.log("with data=" + str(self.resource_params))
+        self.update_resource_params()
+        is_resource_updated = self.check_for_update(
+            self.existing_resource, self.resource_params)
+
+        if not is_resource_updated:
+            # Either the resource does not exist or it exists but was not
+            # updated in the YAML.
+            if self.module.check_mode:
+                successful_resource_exec_logs.append({
+                    self.id: {
+                        "changed": True,
+                        "debug_out": str(json.dumps(self.resource_params)),
+                        "id": '12345',
+                        "resource_type": self.get_resource_name()
+                    }
+                })
+                return
+            try:
+                if self.existing_resource:
+                    # Resource already exists
+                    logger.log("Resource was not updated")
+                    successful_resource_exec_logs.append({
+                        self.id: {
+                            "changed": False,
+                            "id": self.id,
+                            "message": "%s with id %s already exists." %
+                            (self.get_resource_name(), self.id),
+                            "resource_type": self.get_resource_name()
+                        }
+                    })
+                    return
+                # Create a new resource
+                logger.log("Resource does not exist")
+                resp = self._send_request_to_API(suffix="/" + self.id,
+                                                 method='PATCH',
+                                                 data=self.resource_params)
+                successful_resource_exec_logs.append({
+                    self.id: {
+                        "changed": True,
+                        "id": resp["id"],
+                        "body": str(resp),
+                        "message": "%s with id %s created." %
+                        (self.get_resource_name(), self.id),
+                        "resource_type": self.get_resource_name()
+                    }
+                })
+            except Exception as err:
+                srel = successful_resource_exec_logs
+                self.module.fail_json(msg="Failed to add %s with id %s."
+                                          "Request body [%s]. Error[%s]."
+                                          % (self.get_resource_name(),
+                                             self.id, self.resource_params,
+                                             to_native(err)
+                                             ),
+                                      successfully_updated_resources=srel)
+        else:
+            # The resource exists and was updated in the YAML.
+            logger.log("Resource exists on server but was updated by user")
+            if self.module.check_mode:
+                successfully_updated_resources.append({
+                    "changed": True,
+                    "debug_out": str(json.dumps(self.resource_params)),
+                    "id": self.id,
+                    "resource_type": self.get_resource_name()
+                })
+                return
+            self.resource_params['_revision'] = \
+                self.existing_resource['_revision']
+            try:
+                resp = self._send_request_to_API(suffix="/"+self.id,
+                                                 method="PATCH",
+                                                 data=self.resource_params)
+                successful_resource_exec_logs.append({
+                    "changed": True,
+                    "id": self.id,
+                    "body": str(resp),
+                    "message": "%s with id %s updated." %
+                    (self.get_resource_name(), self.id),
+                    "resource_type": self.get_resource_name()
+                })
+            except Exception as err:
+                srel = successful_resource_exec_logs
+                self.module.fail_json(msg="Failed to update %s with id %s."
+                                          "Request body [%s]. Error[%s]." %
+                                          (self.get_resource_name(), self.id,
+                                           self.resource_params, to_native(err)
+                                           ),
+                                      successfully_updated_resources=srel)
+
+    def _achieve_absent_state(self, successful_resource_exec_logs):
+        if self.existing_resource is None:
+            successful_resource_exec_logs.append({
+                self.id: {
+                    "changed": False,
+                    "msg": 'No %s exist with id %s' %
+                    (self.get_resource_name(), self.id),
+                    "resource_type": self.get_resource_name()
+                }
+            })
+            return
+        if self.module.check_mode:
+            successful_resource_exec_logs.append({
+                "changed": True,
+                "debug_out": str(json.dumps(self.resource_params)),
+                "id": self.id,
+                "resource_type": self.get_resource_name()
+            })
+            return
+        try:
+            _ = self._send_request_to_API("/" + self.id, method='DELETE')
+            self._wait_till_delete()
+            successful_resource_exec_logs.append({
+                "changed": True,
+                "id": self.id,
+                "message": "%s with id %s deleted." %
+                (self.get_resource_name(), self.id)
+            })
+        except Exception as err:
+            srel = successful_resource_exec_logs
+            self.module.fail_json(msg="Failed to delete %s with id %s. "
+                                      "Error[%s]." % (self.get_resource_name(),
+                                                      self.id, to_native(err)),
+                                  successfully_updated_resources=srel)
+
+    def achieve_state(self, successful_resource_exec_logs=[]):
+        """
+            Achieves `present` or `absent` state as specified in the YAML.
+        """
+        logger.log("Achieving " + self._state + " state")
+        if self.id == self.INCORRECT_ARGUMENT_NAME_VALUE:
+            # The resource was not specified in the YAML.
+            return
+        self.achieve_subresource_state(successful_resource_exec_logs)
+
+        if self._state == 'present':
+            self._achieve_present_state(successful_resource_exec_logs)
+        else:
+            self._achieve_absent_state(successful_resource_exec_logs)
+
+        if self.get_resource_name() in constants.BASE_RESOURCES:
+            self.module.exit_json(
+                successfully_updated_resources=successful_resource_exec_logs)
+
+    def achieve_subresource_state(self, successful_resource_exec_logs):
+        """
+            Achieve the state of each sub-resource.
+        """
+        for attr in self.__class__.__dict__.values():
+            if inspect.isclass(attr) and issubclass(attr, NSXTAnsibleResource):
+                sub_resource = attr()
+                sub_resource.achieve_state(successful_resource_exec_logs)
+
+    def wait_till_create(self):
+        pass
+
+    def _wait_till_delete(self):
+        """
+            Periodically checks if the resource still exists on the API server
+            every 10 seconds. Returns after it has been deleted.
+        """
+        while True:
+            try:
+                self._send_request_to_API("/" + self.id)
+                time.sleep(10)
+            except DuplicateRequestError:
+                self.module.fail_json(msg='Duplicate request')
+            except Exception as err:
+                time.sleep(5)
+                return
+
+    def update_resource_params(self):
+        # Should be overridden in the subclass if needed
+        pass
+
+    def _fill_missing_resource_params(self, existing_params, resource_params):
+        """
+            resource_params: dict
+            existing_params: dict
+
+            Fills resource_params with the key:value from existing_params if
+            missing in the former.
+        """
+        if not existing_params:
+            return
+        for k, v in existing_params.items():
+            if k not in resource_params:
+                resource_params[k] = v
+            elif type(v).__name__ == 'dict':
+                self._fill_missing_resource_params(v, resource_params[k])
+
+    def check_for_update(self, existing_params, resource_params):
+        """
+            resource_params: dict
+            existing_params: dict
+
+            Compares the existing_params with resource_params and returns
+            True if they are different.
+        """
+        if not existing_params:
+            return False
+        for k, v in resource_params.items():
+            if k not in existing_params:
+                return True
+            elif type(v).__name__ == 'dict':
+                if self.check_for_update(existing_params[k], v):
+                    return True
+            elif v != existing_params[k]:
+                return True
+        return False

--- a/policy-ansible-for-nsxt/module_utils/PolicyCommunicator.py
+++ b/policy-ansible-for-nsxt/module_utils/PolicyCommunicator.py
@@ -1,0 +1,141 @@
+import json
+import hashlib
+
+from ansible.module_utils.urls import open_url
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+
+from ansible.module_utils.Logger import Logger
+logger = Logger.getInstance()
+
+
+class PolicyCommunicator:
+
+    __instances = dict()
+
+    @staticmethod
+    def get_instance(mgr_username, mgr_hostname, mgr_password):
+        """
+            Returns an instance of PolicyCommunicator associated with
+            mgr_username, mgr_hostname, mgr_password
+        """
+        key = tuple([mgr_username, mgr_hostname, mgr_password])
+        if key not in PolicyCommunicator.__instances:
+            PolicyCommunicator(mgr_username, mgr_hostname,
+                               mgr_password)
+        return PolicyCommunicator.__instances.get(key)
+
+    def __init__(self, mgr_username, mgr_hostname, mgr_password):
+        key = tuple([mgr_username, mgr_hostname, mgr_password])
+        if key in PolicyCommunicator.__instances:
+            raise Exception("The associated PolicyCommunicator is"
+                            " already present! Please use getInstance to"
+                            " retrieve it.")
+        else:
+            self.mgr_username = mgr_username
+            self.policy_url = 'https://{}/policy/api/v1'.format(mgr_hostname)
+            self.mgr_password = mgr_password
+            self.active_requests = set()
+
+            PolicyCommunicator.__instances[key] = self
+
+    @staticmethod
+    def get_vmware_argument_spec():
+        return dict(
+            hostname=dict(type='str', required=True),
+            username=dict(type='str', required=True),
+            password=dict(type='str', required=True, no_log=True),
+            port=dict(type='int', default=443),
+            validate_certs=dict(type='bool', requried=False, default=True)
+        )
+
+    def request(self, url, data=None, headers={'Accept': 'application/json',
+                'Content-Type': 'application/json'}, method='GET',
+                use_proxy=True, force=False, last_mod_time=None,
+                timeout=300, validate_certs=True, http_agent=None,
+                force_basic_auth=True, ignore_errors=False):
+        # prepend the policy url
+        url = self.policy_url + url
+        # create a request ID associated with this request
+        request_id = self._get_request_id(url, data, method)
+        if self.register_request(request_id):
+            # new request
+            try:
+                # connect to the API server
+                if data is not None:
+                    data = json.dumps(data)
+                response = open_url(url=url, data=data, headers=headers,
+                                    method=method,
+                                    use_proxy=use_proxy, force=force,
+                                    last_mod_time=last_mod_time,
+                                    timeout=timeout,
+                                    validate_certs=validate_certs,
+                                    url_username=self.mgr_username,
+                                    url_password=self.mgr_password,
+                                    http_agent=http_agent,
+                                    force_basic_auth=force_basic_auth)
+                resp_code = response.getcode()
+                resp_raw_data = response.read().decode('utf-8') or None
+                logger.log("Server response: " + str(resp_raw_data))
+            except HTTPError as err:
+                response = err.fp
+                resp_code = response.getcode()
+                resp_raw_data = err.fp.read().decode('utf-8')
+                logger.log("Server Error Response: " + str(resp_raw_data))
+
+            # request completed by the server
+            self.active_requests.remove(request_id)
+
+            try:
+                # infer the response
+                if resp_raw_data:
+                    resp_data = json.loads(resp_raw_data)
+                elif data is not None:
+                    resp_data = json.loads(data)
+                else:
+                    resp_data = None
+            except Exception as e:
+                if ignore_errors:
+                    pass
+                else:
+                    raise Exception(resp_raw_data)
+
+            # return the approprate response code and data
+            if resp_code >= 400 and not ignore_errors:
+                raise Exception(resp_code, None)
+            logger.log("Server RC: " + str(resp_data))
+            if resp_data is not None and 'error_code' in resp_data:
+                logger.log(str(resp_data['error_code']))
+                logger.log(str(resp_data))
+                raise Exception(resp_data['error_code'], resp_data)
+            else:
+                return resp_code, resp_data
+        else:
+            raise DuplicateRequestError
+
+    def _get_request_id(self, url, data=None, method='GET'):
+        """
+            Creates a hash from url, data, and method that can be used
+            as a request ID.
+        """
+        request = dict()
+        request["data"] = data
+        request['request_url'] = url
+        request['request_method'] = method
+
+        return hashlib.md5(json.dumps(request, sort_keys=True).
+                           encode('utf-8')).hexdigest()
+
+    def register_request(self, request_id):
+        """
+            This creates a hash from URL and data and stores it in a cache.
+            If a same hash is created, the request is identified as a duplicate
+            and it returns False. Otherwise, returns True.
+        """
+        if request_id in self.active_requests:
+            return False
+        self.active_requests.add(request_id)
+        return True
+
+
+class DuplicateRequestError(Exception):
+    pass

--- a/policy-ansible-for-nsxt/module_utils/constants.py
+++ b/policy-ansible-for-nsxt/module_utils/constants.py
@@ -1,0 +1,3 @@
+# Add all the base resources that can be configured in the
+# Policy API here. Required to infer base resource params.
+BASE_RESOURCES = {"Segment", "NSXTTier0"}


### PR DESCRIPTION
The base py files include:
1. NSXTAnsibleModule.py: This class must be inherited by all the
   NSX-T resource classes that can be configured in the Policy API.
2. PolicyCommunicator.py: This Singleton class wrt NSX-T manager is
   the sole medium to communicate with NSX-T manager.
3. constants.py: This py file includes all the constants required
   throughout the Ansible Modules.
4. Logger.py: This is a helper class which can be utilized to write logs
   for DEBUG purpose.

Signed-off-by: Gautam Verma <gautam94verma@gmail.com>, <vermag@vmware.com>