### PR TITLE
SSLContext support and correction in edge cluster playbook

### DIFF
--- a/test_edge_clusters.yml
+++ b/test_edge_clusters.yml
@@ -12,7 +12,7 @@
         validate_certs: False
         display_name: edge-cluster-1
         cluster_profile_bindings:
-        - profile_id: 91bcaa06-47a1-11e4-8316-17ffc770799b
+        - profile_name: "Profile01"
           resource_type: EdgeHighAvailabilityProfile
         members:
         - transport_node_name: "TN_1"


### PR DESCRIPTION
- SSLContext attribute was not supported in python versions
   earlier than 2.7.9. Thus, caused errors with vCenter utils.
   The support is now added for all python 2.7 all versions.

- Playbook file test_edge_cluster was not updated. The
   parameter it takes are updated.