### PR TITLE
Added setup.py for pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+
+from __future__ import print_function
+
+import os
+import sys
+import glob
+
+from setuptools import setup
+
+ansible_path = "{}/site-packages/ansible".format(os.path.dirname(os.__file__))
+ansible_rel_path = os.path.relpath(ansible_path, sys.prefix)
+
+nsxt_modules = glob.glob('library/*.py')
+nsxt_module_utils = glob.glob('module_utils/*.py')
+
+setup(name='ansible-nsxt-modules',
+      version='1.0.0',
+      description='Ansible modules for VMware NSX-T',
+      url='https://github.com/vmware/ansible-for-nsxt',
+      author='VMware, Inc.',
+      license='BSD 2-Clause or GPLv3',
+      data_files=[
+        ('{}/module_utils'.format(ansible_rel_path), nsxt_module_utils),
+        ('{}/modules/network/nsxt'.format(ansible_rel_path), nsxt_modules)
+      ],
+      install_requires=[
+        'pyvmomi',
+        'pyvim',
+        'requests',
+        'ansible'
+      ],
+      classifiers=[
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)'
+        'Programming Language :: Python',
+      ]
+      )


### PR DESCRIPTION
_The original PR is open on the master branch. This PR also includes commits from current master, as it is tested and will work only with already solved issues (e.g. conflicting module_utils filename fix)._

Enables the installation using pip (e.g. after merging `pip install git+https://github.com/vmware/ansible-for-nsxt.git@development/pscoe`).
Dynamically adds modules and module_utils to the ansible installation of current environment.

Installs the python requirements, but ovf tools should still be installed separately.

Tested from my branch on centos7 container with in Python2 and Python3 venvs.

## Python 2 env
```
docker run -it centos /bin/bash
yum install -y epel-release
yum update -y
yum install -y gcc
yum install -y python36 python36-pip python2-pip git python-virtualenv python-devel python36-devel

[root@78a89263ae5e /]# virtualenv -p python /venv_p2/
[root@78a89263ae5e /]# source /venv_p2/bin/activate
(venv_p2) [root@78a89263ae5e /]# pip install ansible
(venv_p2) [root@78a89263ae5e /]# pip install git+https://github.com/khnazaretyan/ansible-for-nsxt.git@development/pscoe
(venv_p2) [root@78a89263ae5e /]# find /venv_p2/ -name "*nsxt*"
/venv_p2/lib/python2.7/site-packages/ansible_nsxt_modules-1.0.0-py2.7.egg-info
/venv_p2/lib/python2.7/site-packages/ansible/module_utils/vmware_nsxt.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_logical_router_static_routes.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_uplink_profiles.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_compute_collection_fabric_templates.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_controller_manager_auto_deployment.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_ip_pools_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_transport_zones.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_uplink_profiles_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_transport_nodes.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_transport_nodes_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_ip_blocks_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_transport_node_profiles_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_logical_switches.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_edge_clusters.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_deploy_ova.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_transport_zones_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_fabric_compute_managers_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_fabric_nodes_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_manager_status.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_transport_node_collections_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_logical_routers_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_logical_routers.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_compute_collection_fabric_templates_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_licenses_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_edge_clusters_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_ip_pools.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_transport_node_profiles.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_compute_collection_transport_templates_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_licenses.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_logical_ports_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_fabric_nodes.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_ip_blocks.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_transport_node_collections.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_logical_ports.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_route_advertise.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_logical_router_ports_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_fabric_compute_managers.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_logical_switches_facts.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_compute_collection_transport_templates.py
/venv_p2/lib/python2.7/site-packages/ansible/modules/network/nsxt/nsxt_logical_router_ports.py
```

## Python 3 env
```
[root@78a89263ae5e /]# virtualenv -p python36 /venv_p3/
[root@78a89263ae5e /]# source /venv_p3/bin/activate
(venv_p3) [root@78a89263ae5e /]# pip3 install ansible
(venv_p3) [root@78a89263ae5e /]# pip3 install git+https://github.com/khnazaretyan/ansible-for-nsxt.git@development/pscoe
Collecting git+https://github.com/khnazaretyan/ansible-for-nsxt.git@feat-setup_pip
  Cloning https://github.com/khnazaretyan/ansible-for-nsxt.git (to revision feat-setup_pip) to /tmp/pip-req-build-8e6iom66
  Running command git clone -q https://github.com/khnazaretyan/ansible-for-nsxt.git /tmp/pip-req-build-8e6iom66
  Running command git checkout -b feat-setup_pip --track origin/feat-setup_pip
  Switched to a new branch 'feat-setup_pip'
  Branch feat-setup_pip set up to track remote branch feat-setup_pip from origin.
Requirement already satisfied: pyvmomi in /venv_p3/lib/python3.6/site-packages (from ansible-nsxt-modules==1.0.0) (6.7.1.2018.12)
Requirement already satisfied: pyvim in /venv_p3/lib/python3.6/site-packages (from ansible-nsxt-modules==1.0.0) (2.0.24)
Requirement already satisfied: requests in /venv_p3/lib/python3.6/site-packages (from ansible-nsxt-modules==1.0.0) (2.22.0)
Requirement already satisfied: six>=1.7.3 in /venv_p3/lib/python3.6/site-packages (from pyvmomi->ansible-nsxt-modules==1.0.0) (1.12.0)
Requirement already satisfied: docopt in /venv_p3/lib/python3.6/site-packages (from pyvim->ansible-nsxt-modules==1.0.0) (0.6.2)
Requirement already satisfied: prompt-toolkit<2.1.0,>=2.0.0 in /venv_p3/lib/python3.6/site-packages (from pyvim->ansible-nsxt-modules==1.0.0) (2.0.9)
Requirement already satisfied: pygments in /venv_p3/lib/python3.6/site-packages (from pyvim->ansible-nsxt-modules==1.0.0) (2.4.2)
Requirement already satisfied: pyflakes in /venv_p3/lib/python3.6/site-packages (from pyvim->ansible-nsxt-modules==1.0.0) (2.1.1)
Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /venv_p3/lib/python3.6/site-packages (from requests->ansible-nsxt-modules==1.0.0) (3.0.4)
Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /venv_p3/lib/python3.6/site-packages (from requests->ansible-nsxt-modules==1.0.0) (1.25.3)
Requirement already satisfied: certifi>=2017.4.17 in /venv_p3/lib/python3.6/site-packages (from requests->ansible-nsxt-modules==1.0.0) (2019.6.16)
Requirement already satisfied: idna<2.9,>=2.5 in /venv_p3/lib/python3.6/site-packages (from requests->ansible-nsxt-modules==1.0.0) (2.8)
Requirement already satisfied: wcwidth in /venv_p3/lib/python3.6/site-packages (from prompt-toolkit<2.1.0,>=2.0.0->pyvim->ansible-nsxt-modules==1.0.0) (0.1.7)
Building wheels for collected packages: ansible-nsxt-modules
  Building wheel for ansible-nsxt-modules (setup.py) ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-g4vzjrkr/wheels/82/51/3b/30e07f6c1f55c1129bbf398de9a962067fd8cd31e8b968b2bb
Successfully built ansible-nsxt-modules
Installing collected packages: ansible-nsxt-modules
Successfully installed ansible-nsxt-modules-1.0.0

(venv_p3) [root@78a89263ae5e /]# find /venv_p3/ -name "*nsxt*.py"
/venv_p3/lib/python3.6/site-packages/ansible/module_utils/vmware_nsxt.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_logical_router_static_routes.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_uplink_profiles.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_compute_collection_fabric_templates.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_controller_manager_auto_deployment.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_ip_pools_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_transport_zones.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_uplink_profiles_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_transport_nodes.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_transport_nodes_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_ip_blocks_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_transport_node_profiles_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_logical_switches.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_edge_clusters.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_deploy_ova.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_transport_zones_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_fabric_compute_managers_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_fabric_nodes_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_manager_status.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_transport_node_collections_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_logical_routers_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_logical_routers.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_compute_collection_fabric_templates_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_licenses_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_edge_clusters_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_ip_pools.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_transport_node_profiles.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_compute_collection_transport_templates_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_licenses.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_logical_ports_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_fabric_nodes.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_ip_blocks.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_transport_node_collections.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_logical_ports.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_route_advertise.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_logical_router_ports_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_fabric_compute_managers.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_logical_switches_facts.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_compute_collection_transport_templates.py
/venv_p3/lib/python3.6/site-packages/ansible/modules/network/nsxt/nsxt_logical_router_ports.py
```