### PR TITLE
Upgrading SSL protocol for nsx_deploy_ova modules

### DIFF
--- a/library/nsxt_deploy_ova.py
+++ b/library/nsxt_deploy_ova.py
@@ -212,8 +212,8 @@ def connect_to_api(vchost, vc_user, vc_pwd):
         service_instance = SmartConnect(host=vchost, user=vc_user, pwd=vc_pwd)
     except (requests.ConnectionError, ssl.SSLError):
         try:
-            context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-            context.verify_mode = ssl.CERT_NONE
+            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+            context.load_default_certs()
             service_instance = SmartConnect(host=vchost, user=vc_user, pwd=vc_pwd, sslContext=context)
         except Exception as e:
             raise Exception(e)

--- a/library/nsxt_transport_node_profiles.py
+++ b/library/nsxt_transport_node_profiles.py
@@ -168,7 +168,7 @@ def update_params_with_id (module, manager_url, mgr_username, mgr_password, vali
         for host_switch_profile in host_switch_profiles:
             profile_obj = {}
             profile_obj['value'] = get_id_from_display_name (module, manager_url, mgr_username, mgr_password, validate_certs,
-                                                    "/host-switch-profiles", host_switch_profile['name'])
+                                                    "/host-switch-profiles?include_system_owned=true", host_switch_profile['name'])
             profile_obj['key'] = host_switch_profile['type']
             host_switch_profile_ids.append(profile_obj)
         host_switch['host_switch_profile_ids'] = host_switch_profile_ids


### PR DESCRIPTION
Currently, nsx_deploy_ova module was using SSLv23 while connecting to
vCenter. This is now upgraded to TLSv1.2.