### PR TITLE
Enhancement: Support sub-resource list specifications

### DIFF
--- a/policy-ansible-for-nsxt/examples/01_create_t0_gateway.yml
+++ b/policy-ansible-for-nsxt/examples/01_create_t0_gateway.yml
@@ -16,5 +16,6 @@
         display_name: "{{ item.display_name }}"
         ha_mode: "{{ item.ha_mode }}"
         tags: "{{ item.tags }}"
+        locale_services: "{{ item.locale_services }}"
       with_items:
         - "{{ tier0_gateways }}"

--- a/policy-ansible-for-nsxt/examples/build_topology_vars.yml
+++ b/policy-ansible-for-nsxt/examples/build_topology_vars.yml
@@ -4,12 +4,12 @@
 # Variables file to deploy a simple topology
 
 {
-    "nsx_manager" : "10.114.200.11",
-    "nsx_username": "admin",
-    "nsx_password": "VMware1!VMware1!",
+    "nsx_manager": "nsx_manager_IP",
+    "nsx_username": "nsx_username",
+    "nsx_password": "nsx_password",
     "validate_certs": "false",
 
-    "state": "present",
+    "state": "absent",
 
     "tier0_gateways": [
       {
@@ -19,6 +19,26 @@
           {
             "tag": "ansible",
             "scope": "demo"
+          }
+        ],
+        "locale_services": [
+          {
+            "state": "present",
+            "id": "test-t0ls",
+            "route_redistribution_types": ["TIER0_STATIC", "TIER0_NAT"],
+            "edge_cluster_info": {
+              "edge_cluster_id": "7ef91a10-c780-4f48-a279-a5662db4ffa3"
+            },
+            "preferred_edge_nodes_info": [
+              {
+                "edge_cluster_id": "7ef91a10-c780-4f48-a279-a5662db4ffa3",
+                "edge_node_id": "e10c42dc-db27-11e9-8cd0-000c291af7ee"
+              }
+            ],
+            "BGP": {
+              "state": "present",
+              "local_as_num": '1211'
+            }
           }
         ]
       }

--- a/policy-ansible-for-nsxt/library/nsxt_ip_block.py
+++ b/policy-ansible-for-nsxt/library/nsxt_ip_block.py
@@ -56,14 +56,14 @@ options:
 EXAMPLES = '''
 - name: create IP Block
   nsxt_ip_block:
-    hostname: "10.160.84.49"
-      username: "admin"
-      password: "Admin!23Admin"
-      validate_certs: False
-      id: test-ip-blk
-      display_name: test-ip-blk
-      state: "present"
-      cidr: "192.168.0.0/16"
+    hostname: "10.10.10.10"
+    username: "username"
+    password: "password"
+    validate_certs: False
+    id: test-ip-blk
+    display_name: test-ip-blk
+    state: "present"
+    cidr: "192.168.0.0/16"
 '''
 
 RETURN = '''# '''

--- a/policy-ansible-for-nsxt/library/nsxt_policy_group.py
+++ b/policy-ansible-for-nsxt/library/nsxt_policy_group.py
@@ -68,20 +68,20 @@ options:
 EXAMPLES = '''
 - name: create Policy Group
   nsxt_policy_group:
-  hostname: "10.160.84.49"
-  username: "admin"
-  password: "Admin!23Admin"
-  validate_certs: False
-  id: test-lb-service
-  display_name: test-lb-service
-  state: "present"
-  domain_id: "default"
-  expression:
-    - member_type: "VirtualMachine"
-      value: "webvm"
-      key: "Tag"
-      operator: "EQUALS"
-      resource_type: "Condition"
+    hostname: "10.10.10.10"
+    username: "username"
+    password: "password"
+    validate_certs: False
+    id: test-lb-service
+    display_name: test-lb-service
+    state: "present"
+    domain_id: "default"
+    expression:
+      - member_type: "VirtualMachine"
+        value: "webvm"
+        key: "Tag"
+        operator: "EQUALS"
+        resource_type: "Condition"
 '''
 
 RETURN = '''# '''
@@ -114,6 +114,9 @@ class NSXTPolicyGroup(NSXTBaseRealizableResource):
         return '/infra/domains/{}/groups'.format(
             baseline_args["domain_id"]
         )
+
+    def update_resource_params(self, nsx_resource_params):
+        nsx_resource_params.pop('domain_id')
 
 
 if __name__ == '__main__':

--- a/policy-ansible-for-nsxt/library/nsxt_segment.py
+++ b/policy-ansible-for-nsxt/library/nsxt_segment.py
@@ -107,115 +107,125 @@ options:
                              and IPv6.
                 required: True
                 type: str
-    segp_id:
-        description: The id of the Policy Segment Port.
-        required: false
-        type: str
-    segp_display_name:
+    segment_ports:
+        type: list
         description:
-            - Segment Port display name.
-            - Either this or segp_id must be specified. If both are specified,
-              segp_id takes precedence.
-        required: false
-        type: str
-    segp_description:
-        description:
-            - Segment description.
-        type: str
-    segp_tags:
-        description: Opaque identifiers meaningful to the API user.
-        type: dict
+            - Add the Segment Ports to be create, updated, or deleted in this
+              section
+        element: dict
         suboptions:
-            scope:
-                description: Tag scope.
-                required: true
-                type: str
-            tag:
-                description: Tag value.
-                required: true
-                type: str
-    segp_state:
-        choices:
-            - present
-            - absent
-        description:
-            - "State can be either 'present' or 'absent'. 'present' is used to
-              create or update resource. 'absent' is used to delete resource."
-            - Required if I(segp_id != null)."
-        required: true
-    segp_address_bindings:
-        description: Static address binding used for the port.
-        type: dict
-        suboptions:
-            ip_address:
-                description: IP Address for port binding.
-                type: str
-            mac_address:
-                description: Mac address for port binding.
-                type: str
-            vlan_id:
-                description: VLAN ID for port binding.
-                type: str
-    segp_attachment:
-        description: VIF attachment.
-        type: dict
-        suboptions:
-            allocate_addresses:
-                description: Indicate how IP will be
-                             allocated for the port.
-                type: str
-                choices:
-                    - IP_POOL
-                    - MAC_POOL
-                    - BOTH
-                    - NONE
-            app_id:
-                description: ID used to identify/look up a
-                             child attachment behind a
-                             parent attachment.
-                type: str
-            context_id:
-                description: Parent VIF ID if type is CHILD,
-                             Transport node ID if type is
-                             INDEPENDENT.
-                type: str
             id:
-                description: VIF UUID on NSX Manager.
+                description: The id of the Policy Segment Port.
+                required: false
                 type: str
-            traffic_tag:
-                description: VLAN ID
-                             Not valid when type is INDEPENDENT, mainly used to
-                             identify traffic from different ports in container
-                             use case.
-                type: int
-            type:
-                description: Type of port attachment.
+            display_name:
+                description:
+                    - Segment Port display name.
+                    - Either this or     id must be specified. If both are
+                      specified,     id takes precedence.
+                required: false
                 type: str
+            description:
+                description:
+                    - Segment description.
+                type: str
+            tags:
+                description: Opaque identifiers meaningful to the API user.
+                type: dict
+            suboptions:
+                scope:
+                    description: Tag scope.
+                    required: true
+                    type: str
+                tag:
+                    description: Tag value.
+                    required: true
+                    type: str
+            state:
                 choices:
-                    - PARENT
-                    - CHILD
-                    - INDEPENDENT
+                    - present
+                    - absent
+                description:
+                    - State can be either 'present' or 'absent'. 'present' is
+                      used to create or update resource. 'absent' is used to
+                      delete resource
+                    - Required if I(id != null)
+                required: true
+            address_bindings:
+                description: Static address binding used for the port.
+                type: dict
+                suboptions:
+                ip_address:
+                    description: IP Address for port binding.
+                    type: str
+                mac_address:
+                    description: Mac address for port binding.
+                    type: str
+                vlan_id:
+                    description: VLAN ID for port binding.
+                    type: str
+            attachment:
+                description: VIF attachment.
+                type: dict
+                suboptions:
+                    allocate_addresses:
+                        description: Indicate how IP will be
+                                    allocated for the port.
+                        type: str
+                        choices:
+                            - IP_POOL
+                            - MAC_POOL
+                            - BOTH
+                            - NONE
+                    app_id:
+                        description: ID used to identify/look up a
+                                     child attachment behind a
+                                     parent attachment.
+                        type: str
+                    context_id:
+                        description: Parent VIF ID if type is CHILD,
+                                    Transport node ID if type is
+                                    INDEPENDENT.
+                        type: str
+                    id:
+                        description: VIF UUID on NSX Manager.
+                        type: str
+                    traffic_tag:
+                        description:
+                            - VLAN ID
+                            - Not valid when type is INDEPENDENT, mainly
+                              used to identify traffic from different ports
+                              in container use case
+                        type: int
+                    type:
+                        description: Type of port attachment.
+                        type: str
+                        choices:
+                            - PARENT
+                            - CHILD
+                            - INDEPENDENT
 '''
 
 EXAMPLES = '''
 - name: create Segment
   nsxt_segment:
-    hostname: "10.178.14.49"
-    username: "uname"
+    hostname: "10.10.10.10"
+    username: "username"
     password: "password"
-    state: "present"
     validate_certs: False
-    id: test-seg1
-    display_name: test-seg3
-    tier1_id: "k8s-node-lr"
-    domain_name: "dn1"
-    transport_zone_id: "5f0ea34b-7549-4303-be1e-2ef7ea3155e2"
+    display_name: test-seg-4
+    state: present
+    domain_name: dn1
+    transport_zone_display_name: "1-transportzone-730"
     subnets:
-    - gateway_address: "40.1.1.1/16"
-      dhcp_ranges: [ "40.1.2.0/24" ]
-    segp_id: "test-sp"
-    segp_display_name: "test-sp"
-    segp_state: "present"
+      - gateway_address: "40.1.1.1/16"
+    segment_ports:
+      - display_name: test-sp-1
+        state: present
+      - display_name: test-sp-2
+        state: present
+      - display_name: test-sp-3
+        state: present
 '''
 
 RETURN = '''# '''
@@ -306,48 +316,48 @@ class NSXTSegment(NSXTBaseRealizableResource):
     def get_resource_base_url(baseline_args=None):
         return '/infra/segments'
 
-    def update_resource_params(self):
+    def update_resource_params(self, nsx_resource_params):
         if self.do_resource_params_have_attr_with_id_or_display_name(
                 "tier0"):
             tier0_base_url = NSXTTier0.get_resource_base_url()
             tier0_id = self.get_id_using_attr_name_else_fail(
-                "tier0", self.resource_params,
+                "tier0", nsx_resource_params,
                 tier0_base_url, "Tier0")
-            self.resource_params["connectivity_path"] = (
+            nsx_resource_params["connectivity_path"] = (
                 tier0_base_url + "/" + tier0_id)
         elif self.do_resource_params_have_attr_with_id_or_display_name(
                 "tier1"):
             tier1_base_url = NSXTTier1.get_resource_base_url()
             tier1_id = self.get_id_using_attr_name_else_fail(
-                "tier1", self.resource_params,
+                "tier1", nsx_resource_params,
                 tier1_base_url, "Tier1")
-            self.resource_params["connectivity_path"] = (
+            nsx_resource_params["connectivity_path"] = (
                 tier1_base_url + "/" + tier1_id)
 
         if self.do_resource_params_have_attr_with_id_or_display_name(
                 "transport_zone"):
-            site_id = self.resource_params.pop("site_id")
-            enforcementpoint_id = self.resource_params.pop(
+            site_id = nsx_resource_params.pop("site_id")
+            enforcementpoint_id = nsx_resource_params.pop(
                 "enforcementpoint_id")
             transport_zone_base_url = (
                 NSXTPolicyTransportZone.get_resource_base_url(
                     site_id, enforcementpoint_id))
             transport_zone_id = self.get_id_using_attr_name_else_fail(
-                "transport_zone", self.resource_params,
+                "transport_zone", nsx_resource_params,
                 transport_zone_base_url, "Transport Zone")
-            self.resource_params["transport_zone_path"] = (
+            nsx_resource_params["transport_zone_path"] = (
                 transport_zone_base_url + "/" + transport_zone_id)
 
     def update_parent_info(self, parent_info):
         parent_info["segment_id"] = self.id
 
     class NSXTSegmentPort(NSXTBaseRealizableResource):
-        def get_unique_arg_identifier(self):
-            return NSXTSegment.NSXTSegmentPort.get_unique_arg_identifier()
+        def get_spec_identifier(self):
+            return NSXTSegment.NSXTSegmentPort.get_spec_identifier()
 
-        @staticmethod
-        def get_unique_arg_identifier():
-            return "segp"
+        @classmethod
+        def get_spec_identifier(cls):
+            return "segment_ports"
 
         @staticmethod
         def get_resource_spec():

--- a/policy-ansible-for-nsxt/library/nsxt_tier0.py
+++ b/policy-ansible-for-nsxt/library/nsxt_tier0.py
@@ -127,452 +127,519 @@ options:
         description: Same as dhcp_config_id. Either one can be specified.
                      If both are specified, dhcp_config_id takes precedence.
         type: str
-    t0ls_id:
-        description: Tier-0 Locale Service ID.
-        required: false
-        type: str
-    t0ls_display_name:
-        description:
-            - Tier-0 Locale Service display name.
-            - Either this or t0ls_id must be specified. If both are specified,
-              t0ls_id takes precedence.
-        required: false
-        type: str
-    t0ls_description:
-        description:
-            - Tier-0 Locale Service  description.
-        type: str
-    t0ls_state:
-        description:
-            - "State can be either 'present' or 'absent'. 'present' is used to
-               create or update resource. 'absent' is used to delete resource."
-            - Required if t0ls_id is specified.
-        choices:
-            - present
-            - absent
-    t0ls_tags:
-        description: Opaque identifiers meaningful to the API user
-        type: dict
-        suboptions:
-            scope:
-                description: Tag scope.
-                required: true
-                type: str
-            tag:
-                description: Tag value.
-                required: true
-                type: str
-    t0ls_edge_cluster_info:
-        description: Used to create path to edge cluster. Auto-assigned
-                     if associated enforcement-point has only one edge
-                     cluster.
-        type: dict
-        suboptions:
-            site_id:
-                description: site_id where edge cluster is located
-                default: default
-                type: str
-            enforcementpoint_id:
-                description: enforcementpoint_id where edge cluster is
-                             located
-                default: default
-                type: str
-            edge_cluster_id:
-                description: ID of the edge cluster
-                type: str
-            edge_cluster_display_name:
-                description:
-                    - display name of the edge cluster.
-                    - Either this or edge_cluster_id must be specified. If
-                      both are specified, edge_cluster_id takes precedence
-                type: str
-    t0ls_preferred_edge_nodes_info:
-        description: Used to create paths to edge nodes. Specified edge
-                     is used as preferred edge cluster member when
-                     failover mode is set to PREEMPTIVE, not
-                     applicable otherwise.
+    locale_services:
         type: list
+        element: dict
+        description: This is a list of Locale Services that need to be created,
+                     updated, or deleted
         suboptions:
-            site_id:
-                description: site_id where edge node is located
-                default: default
+            id:
+                description: Tier-0 Locale Service ID.
+                required: false
                 type: str
-            enforcementpoint_id:
-                description: enforcementpoint_id where edge node is
-                             located
-                default: default
-                type: str
-            edge_cluster_id:
-                description: edge_cluster_id where edge node is
-                             located
-                type: str
-            edge_cluster_display_name:
+            display_name:
                 description:
-                    - display name of the edge cluster.
-                    - either this or edge_cluster_id must be specified. If
-                      both are specified, edge_cluster_id takes precedence
+                    - Tier-0 Locale Service display name.
+                    - Either this or id must be specified. If both are
+                      specified, id takes precedence
+                required: false
                 type: str
-            edge_node_id:
-                description: ID of the edge node
-                type: str
-            edge_node_display_name:
+            description:
                 description:
-                    - Display name of the edge node.
-                    - either this or edge_node_id must be specified. If
-                      both are specified, edge_node_id takes precedence.
+                    - Tier-0 Locale Service  description.
                 type: str
-    t0ls_route_redistribution_types:
-        description: Enable redistribution of different types of routes
-                     on Tier-0.
-        choices:
-            - TIER0_STATIC: Redistribute user added static routes.
-            - TIER0_CONNECTED: Redistribute all subnets configured on
-                               Interfaces and routes related to
-                               TIER0_ROUTER_LINK, TIER0_SEGMENT,
-                               TIER0_DNS_FORWARDER_IP,
-                               TIER0_IPSEC_LOCAL_IP, TIER0_NAT types.
-            - TIER0_EXTERNAL_INTERFACE: Redistribute external interface
-                                        subnets on Tier-0.
-            - TIER0_LOOPBACK_INTERFACE: Redistribute loopback interface
-                                        subnets on Tier-0.
-            - TIER0_SEGMENT: Redistribute subnets configured on
-                             Segments connected to Tier-0.
-            - TIER0_ROUTER_LINK: Redistribute router link port subnets
-                                 on Tier-0.
-            - TIER0_SERVICE_INTERFACE: Redistribute Tier0 service
-                                       interface subnets.
-            - TIER0_DNS_FORWARDER_IP: Redistribute DNS forwarder
-                                      subnets.
-            - TIER0_IPSEC_LOCAL_IP: Redistribute IPSec subnets.
-            - TIER0_NAT: Redistribute NAT IPs owned by Tier-0.
-            - TIER1_NAT: Redistribute NAT IPs advertised by Tier-1 instances.
-            - TIER1_LB_VIP: Redistribute LB VIP IPs advertised by Tier-1
-              instances.
-            - TIER1_LB_SNAT: Redistribute LB SNAT IPs advertised by Tier-1
-              instances.
-            - TIER1_DNS_FORWARDER_IP: Redistribute DNS forwarder subnets on
-              Tier-1 instances.
-            - TIER1_CONNECTED: Redistribute all subnets configured on Segments
-              and Service Interfaces.
-            - TIER1_SERVICE_INTERFACE: Redistribute Tier1 service interface
-              subnets.
-            - TIER1_SEGMENT: Redistribute subnets configured on Segments
-              connected to Tier1.
-            - TIER1_IPSEC_LOCAL_ENDPOINT: Redistribute IPSec VPN local-endpoint
-              subnets advertised by TIER1.
-        type: list
-    t0ls_bgp_ecmp:
-        description: Flag to enable ECMP.
-        type: bool
-        required: False
-        default: True
-    t0ls_bgp_enabled:
-        description: Flag to enable BGP configuration. Disabling will stop
-                     feature and BGP peering.
-        type: bool
-        required: False
-        default: True
-    t0ls_bgp_graceful_restart_config:
-        description: Configuration field to hold BGP Restart mode and timer.
-        type: dict
-        required: False
-        suboptions:
-            mode:
-                description: BGP Graceful Restart Configuration Mode
-                    - If mode is DISABLE, then graceful restart and helper
-                      modes are disabled.
-                    - If mode is GR_AND_HELPER, then both graceful restart and
-                      helper modes are enabled.
-                    - If mode is HELPER_ONLY, then helper mode is enabled.
-                      HELPER_ONLY mode is the ability for a BGP speaker to
-                      indicate its ability to preserve forwarding state during
-                      BGP restart.
-                    - GRACEFUL_RESTART mode is the ability of a BGP speaker to
-                      advertise its restart to its peers.
-                type: str
-                required: False
-                default: 'HELPER_ONLY'
+            state:
+                description:
+                    - State can be either 'present' or 'absent'. 'present' is
+                      used to create or update resource. 'absent' is used to
+                      delete resource
+                    - Required if id is specified.
                 choices:
-                    - DISABLE
-                    - GR_AND_HELPER
-                    - HELPER_ONLY
-            timer:
-                description: BGP Graceful Restart Timer
+                    - present
+                    - absent
+            tags:
+                description: Opaque identifiers meaningful to the API user
                 type: dict
-                required: False
                 suboptions:
-                    restart_timer:
+                    scope:
+                        description: Tag scope.
+                        required: true
+                        type: str
+                    tag:
+                        description: Tag value.
+                        required: true
+                        type: str
+            edge_cluster_info:
+                description: Used to create path to edge cluster. Auto-assigned
+                            if associated enforcement-point has only one edge
+                            cluster.
+                type: dict
+                suboptions:
+                    site_id:
+                        description: site_id where edge cluster is located
+                        default: default
+                        type: str
+                    enforcementpoint_id:
+                        description: enforcementpoint_id where edge cluster is
+                                    located
+                        default: default
+                        type: str
+                    edge_cluster_id:
+                        description: ID of the edge cluster
+                        type: str
+                    edge_cluster_display_name:
                         description:
-                            - BGP Graceful Restart Timer
-                            - Maximum time taken (in seconds) for a BGP session
-                              to be established after a restart. This can be
-                              used to speed up routing convergence by its peer
-                              in case the BGP speaker does not come back up
-                              after a restart. If the session is not
-                              re-established within this timer, the receiving
-                              speaker will delete all the stale routes from
-                              that peer. Min 1 and Max 3600
-                        type: int
-                        default: 180
-                    stale_route_timer:
+                            - display name of the edge cluster.
+                            - Either this or edge_cluster_id must be specified.
+                              If both are specified, edge_cluster_id takes
+                              precedence
+                        type: str
+            preferred_edge_nodes_info:
+                description: Used to create paths to edge nodes. Specified edge
+                            is used as preferred edge cluster member when
+                            failover mode is set to PREEMPTIVE, not
+                            applicable otherwise.
+                type: list
+                suboptions:
+                    site_id:
+                        description: site_id where edge node is located
+                        default: default
+                        type: str
+                    enforcementpoint_id:
+                        description: enforcementpoint_id where edge node is
+                                    located
+                        default: default
+                        type: str
+                    edge_cluster_id:
+                        description: edge_cluster_id where edge node is
+                                    located
+                        type: str
+                    edge_cluster_display_name:
                         description:
-                            - BGP Stale Route Timer
-                            - Maximum time (in seconds) before stale routes are
-                              removed from the RIB (Routing Information Base)
-                              when BGP restarts. Min 1 and Max 3600
-                        type: int
-                        default: 600
-    t0ls_bgp_inter_sr_ibgp:
-        description: Flag to enable inter SR IBGP configuration. When not
-                     specified, inter SR IBGP is automatically enabled if
-                     Tier-0 is created in ACTIVE_ACTIVE ha_mode.
-        type: bool
-        required: False
-    t0ls_bgp_local_as_num:
-        description:
-            - BGP AS number in ASPLAIN/ASDOT Format.
-            - Specify BGP AS number for Tier-0 to advertize to BGP peers.
-              AS number can be specified in ASPLAIN (e.g., "65546") or
-              ASDOT (e.g., "1.10") format. Empty string disables BGP feature.
-        type: str
-        required: True
-    t0ls_bgp_multipath_relax:
-        description: Flag to enable BGP multipath relax option.
-        type: bool
-        default: True
-    t0ls_bgp_route_aggregations:
-        description: List of routes to be aggregated
-        type: dict
-        required: False
-        suboptions:
-            prefix:
-                description: CIDR of aggregate address
-                type: str
-                required: True
-            summary_only:
-                description:
-                    - Send only summarized route.
-                    - Summarization reduces number of routes advertised by
-                      representing multiple related routes with prefix
-                      property.
-                type: bool
-                default: True
-    t0ls_bgp_neighbor_allow_as_in:
-        description: Flag to enable allowas_in option for BGP neighbor
-        type: bool
-        default: False
-    t0ls_bgp_neighbor_bfd:
-        description:
-            - BFD configuration for failure detection.
-            - BFD is enabled with default values when not configured.
-        type: dict
-        required: False
-        suboptions:
-            enabled:
-                description: Flag to enable BFD cofiguration
-                type: bool
-                required: False
-            interval:
-                description: Time interval between heartbeat packets in
-                             milliseconds. Min 300 and Max 60000
-                type: int
-                default: 1000
-            multiple:
-                description:
-                    - Declare dead multiple.
-                    - Number of times heartbeat packet is missed before BFD
-                      declares the neighbor is down. Min 2 and Max 16
-                type: int
-                default: 3
-    t0ls_bgp_neighbor_graceful_restart_mode:
-        description:
-            - BGP Graceful Restart Configuration Mode
-            - If mode is DISABLE, then graceful restart and helper modes are
-              disabled.
-            - If mode is GR_AND_HELPER, then both graceful restart and helper
-              modes are enabled.
-            - If mode is HELPER_ONLY, then helper mode is enabled. HELPER_ONLY
-              mode is the ability for a BGP speaker to indicate its ability
-              to preserve forwarding state during BGP restart.
-            - GRACEFUL_RESTART mode is the ability of a BGP speaker to
-              advertise its restart to its peers.
-        type: str
-        choices:
-            - DISABLE
-            - GR_AND_HELPER
-            - HELPER_ONLY
-    t0ls_bgp_neighbor_hold_down_time:
-        description: Wait time in seconds before declaring peer dead. Min 1 and
-                     Max 65535
-        type: int
-        default: 180
-    t0ls_bgp_neighbor_keep_alive_time:
-        description: Interval between keep alive messages sent to peer. Min 1
-                     and Max 65535.
-        type: int
-        default: 60
-    t0ls_bgp_neighbor_maximum_hop_limit:
-        description: Maximum number of hops allowed to reach BGP neighbor.
-                     Min 1 and Max 255
-        type: int
-        default: 1
-    t0ls_bgp_neighbor_neighbor_address:
-        description: Neighbor IP Address
-        type: str
-        required: True
-    t0ls_bgp_neighbor_remote_as_num:
-        description: 4 Byte ASN of the neighbor in ASPLAIN Format
-        type: str
-        required: True
-    t0ls_bgp_neighbor_route_filtering:
-        description: Enable address families and route filtering in each
-                     direction
-        type: dict
-        required: False
-        suboptions:
-            address_family:
-                description:
-                type: str
-                required: False
+                            - display name of the edge cluster.
+                            - either this or edge_cluster_id must be specified.
+                              If both are specified, edge_cluster_id takes
+                              precedence
+                        type: str
+                    edge_node_id:
+                        description: ID of the edge node
+                        type: str
+                    edge_node_display_name:
+                        description:
+                            - Display name of the edge node.
+                            - either this or edge_node_id must be specified. If
+                              both are specified, edge_node_id takes precedence
+                        type: str
+            route_redistribution_types:
+                description: Enable redistribution of different types of routes
+                            on Tier-0.
                 choices:
-                    - 'IPV4'
-                    - 'IPV6'
-                    - 'VPN'
-            enabled:
-                description: Flag to enable address family.
-                type: bool
-                default: True
-            in_route_filters:
-                description:
-                    - Prefix-list or route map path for IN direction
-                    - Specify path of prefix-list or route map to filter routes
-                      for IN direction.
+                    - TIER0_STATIC - Redistribute user added static routes.
+                    - TIER0_CONNECTED - Redistribute all subnets configured on
+                      Interfaces and routes related to TIER0_ROUTER_LINK,
+                      TIER0_SEGMENT, TIER0_DNS_FORWARDER_IP,
+                      TIER0_IPSEC_LOCAL_IP, TIER0_NAT types.
+                    - TIER0_EXTERNAL_INTERFACE - Redistribute external
+                      interface subnets on Tier-0.
+                    - TIER0_LOOPBACK_INTERFACE - Redistribute loopback
+                      interface subnets on Tier-0.
+                    - TIER0_SEGMENT - Redistribute subnets configured on
+                      Segments connected to Tier-0.
+                    - TIER0_ROUTER_LINK - Redistribute router link port subnets
+                      on Tier-0.
+                    - TIER0_SERVICE_INTERFACE - Redistribute Tier0 service
+                      interface subnets.
+                    - TIER0_DNS_FORWARDER_IP - Redistribute DNS forwarder
+                      subnets.
+                    - TIER0_IPSEC_LOCAL_IP - Redistribute IPSec subnets.
+                    - TIER0_NAT - Redistribute NAT IPs owned by Tier-0.
+                    - TIER1_NAT - Redistribute NAT IPs advertised by Tier-1
+                      instances.
+                    - TIER1_LB_VIP - Redistribute LB VIP IPs advertised by
+                      Tier-1 instances.
+                    - TIER1_LB_SNAT - Redistribute LB SNAT IPs advertised by
+                      Tier-1 instances.
+                    - TIER1_DNS_FORWARDER_IP - Redistribute DNS forwarder
+                      subnets on Tier-1 instances.
+                    - TIER1_CONNECTED - Redistribute all subnets configured on
+                      Segments and Service Interfaces.
+                    - TIER1_SERVICE_INTERFACE - Redistribute Tier1 service
+                      interface subnets.
+                    - TIER1_SEGMENT - Redistribute subnets configured on
+                      Segments connected to Tier1.
+                    - TIER1_IPSEC_LOCAL_ENDPOINT - Redistribute IPSec VPN
+                      local-endpoint subnets advertised by TIER1.
                 type: list
-                required: False
-            out_route_filters:
-                description:
-                    - Prefix-list or route map path for OUT direction
-                    - Specify path of prefix-list or route map to filter routes
-                      for OUT direction. When not specified, a built-in
-                      prefix-list named 'prefixlist-out-default' is
-                      automatically applied.
+            BGP:
+                description: Specify the BGP spec in this section
+                type: dict
+                suboptions:
+                    ecmp:
+                        description: Flag to enable ECMP.
+                        type: bool
+                        required: False
+                        default: True
+                    enabled:
+                        description: Flag to enable BGP configuration.
+                                     Disabling will stop feature and BGP
+                                     peering.
+                        type: bool
+                        default: True
+                    graceful_restart_config:
+                        description: Configuration field to hold BGP Restart
+                                     mode and timer.
+                        type: dict
+                        required: False
+                        suboptions:
+                            mode:
+                                description:
+                                    - BGP Graceful Restart Configuration Mode
+                                    - If mode is DISABLE, then graceful restart
+                                      and helper modes are disabled.
+                                    - If mode is GR_AND_HELPER, then both
+                                      graceful restart and helper modes are
+                                      enabled.
+                                    - If mode is HELPER_ONLY, then helper mode
+                                      is enabled. HELPER_ONLY mode is the
+                                      ability for a BGP speaker to indicate its
+                                      ability to preserve forwarding state
+                                      during BGP restart.
+                                    - GRACEFUL_RESTART mode is the ability of a
+                                      BGP speaker to advertise its restart to
+                                      its peers.
+                                type: str
+                                required: False
+                                default: 'HELPER_ONLY'
+                                choices:
+                                    - DISABLE
+                                    - GR_AND_HELPER
+                                    - HELPER_ONLY
+                            timer:
+                                description: BGP Graceful Restart Timer
+                                type: dict
+                                required: False
+                                suboptions:
+                                    restart_timer:
+                                        description:
+                                            - BGP Graceful Restart Timer
+                                            - Maximum time taken (in seconds)
+                                              for a BGP session to be
+                                              established after a restart. This
+                                              can be used to speed up routing
+                                              convergence by its peer in case
+                                              the BGP speaker does not come
+                                              back up after a restart. If the
+                                              session is not re-established
+                                              within this timer, the receiving
+                                              speaker will delete all the stale
+                                              routes from that peer. Min 1 and
+                                              Max 3600
+                                        type: int
+                                        default: 180
+                                    stale_route_timer:
+                                        description:
+                                            - BGP Stale Route Timer
+                                            - Maximum time (in seconds) before
+                                              stale routes are removed from the
+                                              RIB (Routing Information Base)
+                                              when BGP restarts. Min 1 and Max
+                                              3600
+                                        type: int
+                                        default: 600
+                    inter_sr_ibgp:
+                        description: Flag to enable inter SR IBGP
+                                     configuration. When not specified, inter
+                                     SR IBGP is automatically enabled if Tier-0
+                                     is created in ACTIVE_ACTIVE ha_mode.
+                        type: bool
+                        required: False
+                    local_as_num:
+                        description:
+                            - BGP AS number in ASPLAIN/ASDOT Format.
+                            - Specify BGP AS number for Tier-0 to advertize to
+                              BGP peers. AS number can be specified in ASPLAIN
+                              (e.g., "65546") or ASDOT (e.g., "1.10") format.
+                              Empty string disables BGP feature.
+                        type: str
+                        required: True
+                    multipath_relax:
+                        description: Flag to enable BGP multipath relax option.
+                        type: bool
+                        default: True
+                    route_aggregations:
+                        description: List of routes to be aggregated
+                        type: dict
+                        required: False
+                        suboptions:
+                            prefix:
+                                description: CIDR of aggregate address
+                                type: str
+                                required: True
+                            summary_only:
+                                description:
+                                    - Send only summarized route.
+                                    - Summarization reduces number of routes
+                                      advertised by representing multiple
+                                      related routes with prefix property
+                                type: bool
+                                default: True
+                    neighbors:
+                        description: Specify the BGP neighbors in this section
+                                     that need to be created, updated, or
+                                     deleted
+                        type: list
+                        element: dict
+                        suboptions:
+                            allow_as_in:
+                                description: Flag to enable allowas_in option
+                                             for BGP neighbor
+                                type: bool
+                                default: False
+                            bfd:
+                                description:
+                                    - BFD configuration for failure detection
+                                    - BFD is enabled with default values when
+                                      not configured
+                                type: dict
+                                required: False
+                                suboptions:
+                                    enabled:
+                                        description: Flag to enable BFD
+                                                     cofiguration
+                                        type: bool
+                                        required: False
+                                    interval:
+                                        description: Time interval between
+                                                     heartbeat packets in
+                                                     milliseconds. Min 300 and
+                                                     Max 60000
+                                        type: int
+                                        default: 1000
+                                    multiple:
+                                        description:
+                                            - Declare dead multiple.
+                                            - Number of times heartbeat packet
+                                              is missed before BFD declares the
+                                              neighbor is down.
+                                              Min 2 and Max 16
+                                        type: int
+                                        default: 3
+                            graceful_restart_mode:
+                                description:
+                                    - BGP Graceful Restart Configuration Mode
+                                    - If mode is DISABLE, then graceful restart
+                                      and helper modes are disabled.
+                                    - If mode is GR_AND_HELPER, then both
+                                      graceful restart and helper modes are
+                                      enabled.
+                                    - If mode is HELPER_ONLY, then helper mode
+                                      is enabled. HELPER_ONLY mode is the
+                                      ability for a BGP speaker to indicate its
+                                      ability to preserve forwarding state
+                                      during BGP restart.
+                                    - GRACEFUL_RESTART mode is the ability of a
+                                      BGP speaker to advertise its restart to
+                                      its peers.
+                                type: str
+                                choices:
+                                    - DISABLE
+                                    - GR_AND_HELPER
+                                    - HELPER_ONLY
+                            hold_down_time:
+                                description: Wait time in seconds before
+                                             declaring peer dead. Min 1 and Max
+                                             65535
+                                type: int
+                                default: 180
+                            keep_alive_time:
+                                description: Interval between keep alive
+                                             messages sent to peer. Min 1 and
+                                             Max 65535.
+                                type: int
+                                default: 60
+                            maximum_hop_limit:
+                                description: Maximum number of hops allowed to
+                                             reach BGP neighbor. Min 1 and Max
+                                             255
+                                type: int
+                                default: 1
+                            address:
+                                description: Neighbor IP Address
+                                type: str
+                                required: True
+                            remote_as_num:
+                                description: 4 Byte ASN of the neighbor in
+                                             ASPLAIN Format
+                                type: str
+                                required: True
+                            route_filtering:
+                                description: Enable address families and route
+                                             filtering in each direction
+                                type: dict
+                                required: False
+                                suboptions:
+                                    address_family:
+                                        description:
+                                        type: str
+                                        required: False
+                                        choices:
+                                            - 'IPV4'
+                                            - 'IPV6'
+                                            - 'VPN'
+                                    enabled:
+                                        description: Flag to enable address
+                                                     family
+                                        type: bool
+                                        default: True
+                                    in_route_filters:
+                                        description:
+                                            - Prefix-list or route map path for
+                                              IN direction
+                                            - Specify path of prefix-list or
+                                              route map to filter routes for IN
+                                              direction.
+                                        type: list
+                                        required: False
+                                    out_route_filters:
+                                        description:
+                                            - Prefix-list or route map path for
+                                              OUT direction
+                                            - Specify path of prefix-list or
+                                              route map to filter routes
+                                              for OUT direction. When not
+                                              specified, a built-in
+                                              prefix-list named
+                                              'prefixlist-out-default' is
+                                              automatically applied.
+                                        type: list
+                                        required: False
+                            source_addresses:
+                                description:
+                                    - Source IP Addresses for BGP peering
+                                    - Source addresses should belong to Tier0
+                                      external or loopback interface IP
+                                      Addresses. BGP peering is formed from all
+                                      these addresses. This property is
+                                      mandatory when maximum_hop_limit is
+                                      greater than 1.
+                                type: list
+                                required: False
+            interfaces:
                 type: list
-                required: False
-    t0ls_bgp_neighbor_source_addresses:
-        description:
-            - Source IP Addresses for BGP peering
-            - Source addresses should belong to Tier0 external or loopback
-              interface IP Addresses. BGP peering is formed from all these
-              addresses. This property is mandatory when maximum_hop_limit is
-              greater than 1.
-        type: list
-        required: False
-    t0iface_id:
-        description: Tier-0 Interface ID
-        type: str
-    t0iface_display_name:
-        description:
-            - Tier-0 Interface display name
-            - Either this or t0iface_id must be specified. If both are
-              specified, t0iface_id takes precedence.
-        required: false
-        type: str
-    t0iface_description:
-        description: Tier-0 Interface  description
-        type: str
-    t0iface_state:
-        description:
-            - "State can be either 'present' or 'absent'. 'present' is used to
-              create or update resource. 'absent' is used to delete resource."
-            - Required if I(segp_id != null)."
-        choices:
-            - present
-            - absent
-    t0iface_tags:
-        description: Opaque identifiers meaningful to the API user
-        type: dict
-        suboptions:
-            scope:
-                description: Tag scope.
-                required: true
-                type: str
-            tag:
-                description: Tag value.
-                required: true
-                type: str
-    t0iface_segment_id:
-        description: Specify Segment to which this interface is
-                     connected to.
-                     Required if t0iface_id is specified.
-        type: str
-    t0iface_segment_display_name:
-        description:
-            - Same as t0iface_segment_id
-            - Either this or t0iface_segment_id must be specified. If
-              both are specified, t0iface_segment_id takes precedence.
-        type: str
-    t0iface_type:
-        description: Interface type
-        choices:
-            - "EXTERNAL"
-            - "LOOPBACK"
-            - "SERVICE"
-        default: "EXTERNAL"
-        type: str
-    t0iface_edge_node_info:
-        description:
-            - "Info to create policy path to edge node to handle
-               externalconnectivity."
-            - "Required if interface type is EXTERNAL and
-               I(t0iface_id != null)."
-        type: dict
-        suboptions:
-            site_id:
-                description: site_id where edge node is located
-                default: default
-                type: str
-            enforcementpoint_id:
-                description: enforcementpoint_id where edge node is
-                             located
-                default: default
-                type: str
-            edge_cluster_id:
-                description: edge_cluster_id where edge node is
-                             located
-                type: str
-            edge_cluster_display_name:
-                description:
-                    - display name of the edge cluster.
-                    - either this or edge_cluster_id must be specified. If
-                      both are specified, edge_cluster_id takes precedence
-                type: str
-            edge_node_id:
-                description: ID of the edge node
-                type: str
-            edge_node_display_name:
-                description:
-                    - Display name of the edge node.
-                    - either this or edge_node_id must be specified. If
-                      both are specified, edge_node_id takes precedence.
-                type: str
-    t0iface_subnets:
-        description:
-            - IP address and subnet specification for interface.
-            - Specify IP address and network prefix for interface.
-            - Required if I(t0iface_id != null).
-        type: list
+                element: dict
+                description: Specify the interfaces associated with the Gateway
+                             in this section that need to be created, updated,
+                             or deleted
+                suboptions:
+                    id:
+                        description: Tier-0 Interface ID
+                        type: str
+                    display_name:
+                        description:
+                            - Tier-0 Interface display name
+                            - Either this or id must be specified. If both are
+                              specified, id takes precedence.
+                        required: false
+                        type: str
+                    description:
+                        description: Tier-0 Interface  description
+                        type: str
+                    state:
+                        description:
+                            - State can be either 'present' or 'absent'.
+                              'present' is used to create or update resource.
+                              'absent' is used to delete resource.
+                            - Required if I(segp_id != null)
+                        choices:
+                            - present
+                            - absent
+                    tags:
+                        description: Opaque identifiers meaningful to the API
+                                     user
+                        type: dict
+                        suboptions:
+                            scope:
+                                description: Tag scope.
+                                required: true
+                                type: str
+                            tag:
+                                description: Tag value.
+                                required: true
+                                type: str
+                    segment_id:
+                        description: Specify Segment to which this interface is
+                                     connected to. Required if id is specified.
+                        type: str
+                    segment_display_name:
+                        description:
+                            - Same as segment_id
+                            - Either this or segment_id must be specified. If
+                              both are specified, segment_id takes precedence.
+                        type: str
+                    type:
+                        description: Interface type
+                        choices:
+                            - "EXTERNAL"
+                            - "LOOPBACK"
+                            - "SERVICE"
+                        default: "EXTERNAL"
+                        type: str
+                    edge_node_info:
+                        description:
+                            - Info to create policy path to edge node to
+                              handle externalconnectivity.
+                            - Required if interface type is EXTERNAL and
+                              I(id != null)
+                        type: dict
+                        suboptions:
+                            site_id:
+                                description: site_id where edge node is located
+                                default: default
+                                type: str
+                            enforcementpoint_id:
+                                description: enforcementpoint_id where edge
+                                             node is located
+                                default: default
+                                type: str
+                            edge_cluster_id:
+                                description: edge_cluster_id where edge node is
+                                             located
+                                type: str
+                            edge_cluster_display_name:
+                                description:
+                                    - display name of the edge cluster.
+                                    - either this or edge_cluster_id must be
+                                      specified. If both are specified,
+                                      edge_cluster_id takes precedence
+                                type: str
+                            edge_node_id:
+                                description: ID of the edge node
+                                type: str
+                            edge_node_display_name:
+                                description:
+                                    - Display name of the edge node.
+                                    - either this or edge_node_id must be
+                                      specified. If both are specified,
+                                      edge_node_id takes precedence.
+                                type: str
+                    subnets:
+                        description:
+                            - IP address and subnet specification for interface
+                            - Specify IP address and network prefix for
+                              interface.
+                            - Required if I(id != null).
+                        type: list
 '''
 
 EXAMPLES = '''
 - name: create Tier0
   nsxt_tier0:
-    hostname: "10.160.84.49"
-    username: "admin"
-    password: "Admin!23Admin"
+    hostname: "10.10.10.10"
+    username: "username"
+    password: "password"
     validate_certs: False
-    id: test-tier0
-    display_name: test-tier0
-    state: "present"
+    display_name: test-tier0-1
+    state: present
     ha_mode: "ACTIVE_STANDBY"
     failover_mode: "PREEMPTIVE"
     disable_firewall: True
@@ -580,39 +647,43 @@ EXAMPLES = '''
     tags:
       - scope: "a"
         tag: "b"
-    t0ls_state: "present"
-    t0ls_display_name: "test-t0ls"
-    t0ls_route_redistribution_types: ["TIER0_STATIC", "TIER0_NAT"]
-    t0ls_edge_cluster_info:
-      edge_cluster_display_name: "edgecluster1"
-    t0ls_preferred_edge_nodes_info:
-      - edge_cluster_id: "95196903-6b8a-4276-a7c4-387263e834fd"
-        edge_node_id: "940f1f4b-0317-45d4-84e2-b8c2394e7405"
-    t0ls_bgp_state: "present"
-    t0ls_bgp_local_as_num: 1211
-    t0ls_bgp_inter_sr_ibgp: False
-    t0ls_bgp_graceful_restart_config:
-      mode: "GR_AND_HELPER"
-      timer:
-        restart_timer: 12
-    t0ls_bgp_route_aggregations:
-      - prefix: "10.1.1.0/24"
-      - prefix: "11.1.0.0/16"
-        summary_only: False
-    t0ls_bgp_neighbor_display_name: "neigh1"
-    t0ls_bgp_neighbor_neighbor_address: "1.2.3.4"
-    t0ls_bgp_neighbor_remote_as_num: "12"
-    t0ls_bgp_neighbor_state: "absent"
-    t0iface_id: "test-t0-t0ls-iface"
-    t0iface_display_name: "test-t0-t0ls-iface"
-    t0iface_state: "present"
-    t0iface_subnets:
-      - ip_addresses: ["35.1.1.1"]
-        prefix_len: 24
-    t0iface_segment_display_name: "sg-uplink"
-    t0iface_edge_node_info:
-      edge_cluster_display_name: "edgecluster1"
-      edge_node_id: "0"
+    locale_services:
+      - state: present
+        id: "test-t0ls"
+        route_redistribution_types: ["TIER0_STATIC", "TIER0_NAT"]
+        edge_cluster_info:
+          edge_cluster_id: "7ef91a10-c780-4f48-a279-a5662db4ffa3"
+        preferred_edge_nodes_info:
+          - edge_cluster_id: "7ef91a10-c780-4f48-a279-a5662db4ffa3"
+            edge_node_id: "e10c42dc-db27-11e9-8cd0-000c291af7ee"
+        BGP:
+          state: present
+          local_as_num: '1211'
+          inter_sr_ibgp: False
+          graceful_restart_config:
+          mode: "GR_AND_HELPER"
+          timer:
+            restart_timer: 12
+          route_aggregations:
+            - prefix: "10.1.1.0/24"
+            - prefix: "11.1.0.0/24"
+              summary_only: False
+          neighbors:
+            - display_name: neigh1
+              address: "1.2.3.4"
+              remote_as_num: "12"
+              state: present
+        interfaces:
+          - id: "test-t0-t0ls-iface"
+            display_name: "test-t0-t0ls-iface"
+            state: present
+            subnets:
+              - ip_addresses: ["35.1.1.1"]
+                prefix_len: 24
+            segment_id: "test-seg-4"
+            edge_node_info:
+              edge_cluster_id: "7ef91a10-c780-4f48-a279-a5662db4ffa3"
+              edge_node_id: "e10c42dc-db27-11e9-8cd0-000c291af7ee"
 '''
 
 RETURN = '''# '''
@@ -709,14 +780,14 @@ class NSXTTier0(NSXTBaseRealizableResource):
     def get_resource_base_url(baseline_args=None):
         return '/infra/tier-0s'
 
-    def update_resource_params(self):
+    def update_resource_params(self, nsx_resource_params):
         ipv6_profile_paths = []
         if self.do_resource_params_have_attr_with_id_or_display_name(
                 "ipv6_ndra_profile"):
             ipv6_ndra_profile_base_url = (PolicyIpv6NdraProfiles.
                                           get_resource_base_url())
             ipv6_ndra_profile_id = self.get_id_using_attr_name_else_fail(
-                    "ipv6_ndra_profile", self.resource_params,
+                    "ipv6_ndra_profile", nsx_resource_params,
                     ipv6_ndra_profile_base_url, "Ipv6NdraProfile")
             ipv6_profile_paths.append(
                 ipv6_ndra_profile_base_url + "/" + ipv6_ndra_profile_id)
@@ -725,33 +796,33 @@ class NSXTTier0(NSXTBaseRealizableResource):
             ipv6_dad_profile_base_url = (PolicyIpv6DadProfiles.
                                          get_resource_base_url())
             ipv6_dad_profile_id = self.get_id_using_attr_name_else_fail(
-                    "ipv6_dad_profile", self.resource_params,
+                    "ipv6_dad_profile", nsx_resource_params,
                     ipv6_dad_profile_base_url, "Ipv6DadProfile")
             ipv6_profile_paths.append(
                 ipv6_dad_profile_base_url + "/" + ipv6_dad_profile_id)
         if ipv6_profile_paths:
-            self.resource_params["ipv6_profile_paths"] = ipv6_profile_paths
+            nsx_resource_params["ipv6_profile_paths"] = ipv6_profile_paths
 
         if self.do_resource_params_have_attr_with_id_or_display_name(
                 "dhcp_config"):
             dhcp_config_base_url = (
                 PolicyDhcpRelayConfig.get_resource_base_url())
             dhcp_config_id = self.get_id_using_attr_name_else_fail(
-                "dhcp_config", self.resource_params,
+                "dhcp_config", nsx_resource_params,
                 dhcp_config_base_url, "DhcpRelayConfig")
-            self.resource_params["dhcp_config_paths"] = [
+            nsx_resource_params["dhcp_config_paths"] = [
                 dhcp_config_base_url + "/" + dhcp_config_id]
 
     def update_parent_info(self, parent_info):
         parent_info["tier0_id"] = self.id
 
     class NSXTTier0LocaleService(NSXTBaseRealizableResource):
-        def get_unique_arg_identifier(self):
-            return NSXTTier0.NSXTTier0LocaleService.get_unique_arg_identifier()
+        def get_spec_identifier(self):
+            return NSXTTier0.NSXTTier0LocaleService.get_spec_identifier()
 
-        @staticmethod
-        def get_unique_arg_identifier():
-            return "t0ls"
+        @classmethod
+        def get_spec_identifier(cls):
+            return "locale_services"
 
         @staticmethod
         def get_resource_spec():
@@ -782,6 +853,7 @@ class NSXTTier0(NSXTBaseRealizableResource):
                 preferred_edge_nodes_info=dict(
                     required=False,
                     type='list',
+                    elements='dict',
                     options=dict(
                         # Note that only default site_id and
                         # enforcementpoint_id are used
@@ -819,9 +891,9 @@ class NSXTTier0(NSXTBaseRealizableResource):
             tier0_id = parent_info.get("tier0_id", 'default')
             return '/infra/tier-0s/{}/locale-services'.format(tier0_id)
 
-        def update_resource_params(self):
-            if "edge_cluster_info" in self.resource_params:
-                edge_cluster_info = self.resource_params.pop(
+        def update_resource_params(self, nsx_resource_params):
+            if "edge_cluster_info" in nsx_resource_params:
+                edge_cluster_info = nsx_resource_params.pop(
                     "edge_cluster_info")
                 site_id = edge_cluster_info["site_id"]
                 enforcementpoint_id = edge_cluster_info["enforcementpoint_id"]
@@ -831,13 +903,13 @@ class NSXTTier0(NSXTBaseRealizableResource):
                 edge_cluster_id = self.get_id_using_attr_name_else_fail(
                     "edge_cluster", edge_cluster_info, edge_cluster_base_url,
                     PolicyEdgeCluster.__name__)
-                self.resource_params["edge_cluster_path"] = (
+                nsx_resource_params["edge_cluster_path"] = (
                     edge_cluster_base_url + "/" + edge_cluster_id)
 
-            if "preferred_edge_nodes_info" in self.resource_params:
-                preferred_edge_nodes_info = self.resource_params.pop(
+            if "preferred_edge_nodes_info" in nsx_resource_params:
+                preferred_edge_nodes_info = nsx_resource_params.pop(
                     "preferred_edge_nodes_info")
-                self.resource_params["preferred_edge_paths"] = []
+                nsx_resource_params["preferred_edge_paths"] = []
                 for preferred_edge_node_info in preferred_edge_nodes_info:
                     site_id = preferred_edge_node_info.get(
                         "site_id", "default")
@@ -854,32 +926,30 @@ class NSXTTier0(NSXTBaseRealizableResource):
                     edge_node_id = self.get_id_using_attr_name_else_fail(
                         "edge_node", preferred_edge_node_info,
                         edge_node_base_url, PolicyEdgeNode.__name__)
-                    self.resource_params["preferred_edge_paths"].append(
+                    nsx_resource_params["preferred_edge_paths"].append(
                         edge_node_base_url + "/" + edge_node_id)
 
         def update_parent_info(self, parent_info):
-            parent_info["t0ls_id"] = self.id
+            parent_info["id"] = self.id
 
         class NSXTTier0Interface(NSXTBaseRealizableResource):
-            def get_unique_arg_identifier(self):
+            def get_spec_identifier(self):
                 return (
                     NSXTTier0.NSXTTier0LocaleService.NSXTTier0Interface.
-                    get_unique_arg_identifier())
+                    get_spec_identifier())
 
-            @staticmethod
-            def get_unique_arg_identifier():
-                return "t0iface"
+            @classmethod
+            def get_spec_identifier(cls):
+                return "interfaces"
 
             @staticmethod
             def get_resource_spec():
                 tier0_ls_int_arg_spec = {}
                 tier0_ls_int_arg_spec.update(
                     segment_id=dict(
-                        required=False,
                         type='str'
                     ),
                     segment_display_name=dict(
-                        required=False,
                         type='str'
                     ),
                     edge_node_info=dict(
@@ -913,7 +983,6 @@ class NSXTTier0(NSXTBaseRealizableResource):
                         type='list'
                     ),
                     type=dict(
-                        required=False,
                         type='str',
                         default="EXTERNAL",
                         choices=["EXTERNAL", "SERVICE", "LOOPBACK"]
@@ -924,22 +993,22 @@ class NSXTTier0(NSXTBaseRealizableResource):
             @staticmethod
             def get_resource_base_url(parent_info):
                 tier0_id = parent_info.get("tier0_id", 'default')
-                locale_service_id = parent_info.get("t0ls_id", 'default')
+                locale_service_id = parent_info.get("id", 'default')
                 return ('/infra/tier-0s/{}/locale-services/{}/interfaces'
                         .format(tier0_id, locale_service_id))
 
-            def update_resource_params(self):
+            def update_resource_params(self, nsx_resource_params):
                 # segment_id is a required attr
                 segment_base_url = NSXTSegment.get_resource_base_url()
                 segment_id = self.get_id_using_attr_name_else_fail(
-                    "segment", self.resource_params,
+                    "segment", nsx_resource_params,
                     segment_base_url,
                     "Segment")
-                self.resource_params["segment_path"] = (
+                nsx_resource_params["segment_path"] = (
                     segment_base_url + "/" + segment_id)
 
                 # edge_node_info is a required attr
-                edge_node_info = self.resource_params.pop("edge_node_info")
+                edge_node_info = nsx_resource_params.pop("edge_node_info")
                 site_id = edge_node_info.get("site_id", "default")
                 enforcementpoint_id = edge_node_info.get(
                     "enforcementpoint_id", "default")
@@ -954,7 +1023,7 @@ class NSXTTier0(NSXTBaseRealizableResource):
                 edge_node_id = self.get_id_using_attr_name_else_fail(
                     "edge_node", edge_node_info, edge_node_base_url,
                     PolicyEdgeNode.__name__)
-                self.resource_params["edge_path"] = (
+                nsx_resource_params["edge_path"] = (
                     edge_node_base_url + "/" + edge_node_id)
 
         class NSXTTier0LocaleServiceBGP(NSXTBaseRealizableResource):
@@ -965,26 +1034,24 @@ class NSXTTier0(NSXTBaseRealizableResource):
             def skip_delete(self):
                 return True
 
-            def get_unique_arg_identifier(self):
+            def get_spec_identifier(self):
                 return (
                     NSXTTier0.NSXTTier0LocaleService.NSXTTier0LocaleServiceBGP.
-                    get_unique_arg_identifier())
+                    get_spec_identifier())
 
-            @staticmethod
-            def get_unique_arg_identifier():
-                return "t0ls_bgp"
+            @classmethod
+            def get_spec_identifier(cls):
+                return "BGP"
 
             @staticmethod
             def get_resource_spec():
-                tier0_ls_bgp_arg_spec = {}
-                tier0_ls_bgp_arg_spec.update(
+                tier0_ls_arg_spec = {}
+                tier0_ls_arg_spec.update(
                     ecmp=dict(
-                        required=False,
                         default=True,
                         type='bool'
                     ),
                     enabled=dict(
-                        required=False,
                         default=True,
                         type='bool'
                     ),
@@ -1022,57 +1089,58 @@ class NSXTTier0(NSXTBaseRealizableResource):
                         type='bool'
                     ),
                     local_as_num=dict(
-                        required=True,
                         type='str'
                     ),
                     multipath_relax=dict(
-                        required=False,
                         type='bool',
                         default=True
                     ),
                     route_aggregations=dict(
                         required=False,
                         type='list',
+                        elements='dict',
                         options=dict(
                             prefix=dict(
                                 required=True,
                                 type='str'
                             ),
                             summary_only=dict(
-                                required=False,
                                 type='bool',
                                 default=True
                             )
                         )
                     )
                 )
-                return tier0_ls_bgp_arg_spec
+                return tier0_ls_arg_spec
 
             @staticmethod
             def get_resource_base_url(parent_info):
                 tier0_id = parent_info.get("tier0_id", 'default')
-                locale_service_id = parent_info.get("t0ls_id", 'default')
+                locale_service_id = parent_info.get("id", 'default')
                 return ('/infra/tier-0s/{}/locale-services/{}'
                         .format(tier0_id, locale_service_id))
 
+            @classmethod
+            def allows_multiple_resource_spec(cls):
+                return False
+
             class NSXTTier0LocaleServiceBGPNeighbor(
                     NSXTBaseRealizableResource):
-                def get_unique_arg_identifier(self):
+                def get_spec_identifier(self):
                     return (
                         NSXTTier0.NSXTTier0LocaleService.
                         NSXTTier0LocaleServiceBGP.
-                        get_unique_arg_identifier())
+                        get_spec_identifier())
 
-                @staticmethod
-                def get_unique_arg_identifier():
-                    return "t0ls_bgp_neighbor"
+                @classmethod
+                def get_spec_identifier(cls):
+                    return "neighbors"
 
                 @staticmethod
                 def get_resource_spec():
-                    tier0_ls_bgp_neighbor_arg_spec = {}
-                    tier0_ls_bgp_neighbor_arg_spec.update(
+                    tier0_ls_arg_spec = {}
+                    tier0_ls_arg_spec.update(
                         allow_as_in=dict(
-                            required=False,
                             default=False,
                             type='bool'
                         ),
@@ -1103,21 +1171,18 @@ class NSXTTier0(NSXTBaseRealizableResource):
                             choices=['DISABLE', 'GR_AND_HELPER', 'HELPER_ONLY']
                         ),
                         hold_down_time=dict(
-                            required=False,
                             type='int',
                             default=180
                         ),
                         keep_alive_time=dict(
-                            required=False,
                             type='int',
                             default=60
                         ),
                         maximum_hop_limit=dict(
-                            required=False,
                             type='int',
                             default=1
                         ),
-                        neighbor_address=dict(
+                        address=dict(
                             required=True,
                             type='str'
                         ),
@@ -1154,12 +1219,12 @@ class NSXTTier0(NSXTBaseRealizableResource):
                             type='list'
                         )
                     )
-                    return tier0_ls_bgp_neighbor_arg_spec
+                    return tier0_ls_arg_spec
 
                 @staticmethod
                 def get_resource_base_url(parent_info):
                     tier0_id = parent_info.get("tier0_id", 'default')
-                    locale_service_id = parent_info.get("t0ls_id", 'default')
+                    locale_service_id = parent_info.get("id", 'default')
                     return ('/infra/tier-0s/{}/locale-services/{}'
                             '/bgp/neighbors'.format(tier0_id,
                                                     locale_service_id))

--- a/policy-ansible-for-nsxt/library/nsxt_tier1.py
+++ b/policy-ansible-for-nsxt/library/nsxt_tier1.py
@@ -167,218 +167,244 @@ options:
         type: str
     tier0_display_name:
         description: Same as tier0_id. Either one can be specified.
-                     If both are specified, tier0_id takes precedence.
+                    If both are specified, tier0_id takes precedence.
         type: str
-    t1ls_id:
-        description: Tier-1 Locale Service ID
-        required: false
-        type: str
-    t1ls_display_name:
-        description:
-            - Tier-1 Locale Service display name.
-            - Either this or t1ls_id must be specified. If both are specified,
-              t1ls_id takes precedence.
-        required: false
-        type: str
-    t1ls_description:
-        description: Tier-1 Locale Service  description
-        type: str
-    t1ls_state:
-        description:
-            - "State can be either 'present' or 'absent'. 'present' is used to
-              create or update resource. 'absent' is used to delete resource."
-            - Required if I(segp_id != null)."
-        choices:
-            - present
-            - absent
-    t1ls_tags:
-        description: Opaque identifiers meaningful to the API user.
-        type: dict
-        suboptions:
-            scope:
-                description: Tag scope.
-                required: true
-                type: str
-            tag:
-                description: Tag value.
-                required: true
-                type: str
-    t1ls_edge_cluster_info:
-        description: Used to create path to edge cluster. Auto-assigned
-                     if associated enforcement-point has only one edge
-                     cluster.
-        type: dict
-        suboptions:
-            site_id:
-                description: site_id where edge cluster is located
-                default: default
-                type: str
-            enforcementpoint_id:
-                description: enforcementpoint_id where edge cluster is
-                             located
-                default: default
-                type: str
-            edge_cluster_id:
-                description: ID of the edge cluster
-                required: true
-                type: str
-            edge_cluster_display_name:
-                description:
-                    - display name of the edge cluster.
-                    - Either this or edge_cluster_id must be specified. If
-                      both are specified, edge_cluster_id takes precedence
-                type: str
-    t1ls_preferred_edge_nodes_info:
-        description: Used to create paths to edge nodes. Specified edge
-                     is used as preferred edge cluster member when
-                     failover mode is set to PREEMPTIVE, not
-                     applicable otherwise.
+    locale_services:
         type: list
+        element: dict
+        description: This is a list of Locale Services that need to be created,
+                     updated, or deleted
         suboptions:
-            site_id:
-                description: site_id where edge node is located
-                default: default
+            id:
+                description: Tier-1 Locale Service ID
                 type: str
-            enforcementpoint_id:
-                description: enforcementpoint_id where edge node is
-                             located
-                default: default
-                type: str
-            edge_cluster_id:
-                description: edge_cluster_id where edge node is
-                             located
-                required: true
-                type: str
-            edge_cluster_display_name:
+            display_name:
                 description:
-                    - display name of the edge cluster.
-                    - either this or edge_cluster_id must be specified. If
-                      both are specified, edge_cluster_id takes precedence
+                    - Tier-1 Locale Service display name.
+                    - Either this or id must be specified. If both are
+                      specified, id takes precedence.
+                required: false
                 type: str
-            edge_node_id:
-                description: ID of the edge node
+            description:
+                description: Tier-1 Locale Service  description
                 type: str
-            edge_node_display_name:
+            state:
                 description:
-                    - Display name of the edge node.
-                    - either this or edge_node_id must be specified. If
-                      both are specified, edge_node_id takes precedence.
-                type: str
-    t1ls_route_redistribution_types:
-        description: Enable redistribution of different types of routes
-                     on Tier-1.
-        choices:
-            - TIER1_STATIC: Redistribute all subnets and static routes
-                            advertised by Tier-1s.
-            - TIER1_NAT: Redistribute NAT IPs advertised by Tier-1
-                         instances.
-            - TIER1_LB_VIP: Redistribute LB VIP IPs advertised by
-                            Tier-1 instances.
-            - TIER1_LB_SNAT: Redistribute LB SNAT IPs advertised by
-                             Tier-1 instances.
-            - TIER1_DNS_FORWARDER_IP: Redistribute DNS forwarder
-                                      subnets on Tier-1 instances.
-            - TIER1_CONNECTED: Redistribute all subnets configured on
-                               Segments and Service Interfaces.
-            - TIER1_SERVICE_INTERFACE: Redistribute Tier1 service
-                                       interface subnets.
-            - TIER1_SEGMENT: Redistribute subnets configured on
-                             Segments connected to Tier1.
-            - TIER1_IPSEC_LOCAL_ENDPOINT: Redistribute IPSec VPN
-                                          local-endpoint  subnets
-                                          advertised by TIER1.
-        type: list
-    t1iface_id:
-        description: Tier-1 Interface ID
-        required: false
-        type: str
-    t1iface_description:
-        description: Tier-1 Interface  description
-        type: str
-    t0iface_display_name:
-        description:
-            - Tier-1 Interface display name
-            - Either this or t1iface_id must be specified. If both are
-              specified, t1iface_id takes precedence.
-        required: false
-        type: str
-    t1iface_state:
-        description:
-            - "State can be either 'present' or 'absent'. 'present' is used to
-              create or update resource. 'absent' is used to delete resource."
-            - Required if I(segp_id != null)."
-        choices:
-            - present
-            - absent
-    t1iface_tags:
-        description: Opaque identifiers meaningful to the API user.
-        type: dict
-        suboptions:
-            scope:
-                description: Tag scope.
-                required: true
-                type: str
-            tag:
-                description: Tag value.
-                required: true
-                type: str
-    t1iface_ipv6_ndra_profile_id:
-        description:
-            - "Configrue IPv6 NDRA profile. Only one NDRA profile can be
-               configured."
-            - Required if I(t1iface_id != null).
-        type: str
-    t1iface_segment_id:
-        description:
-            - Specify Segment to which this interface is connected to.
-            - Required if I(t1iface_id != null).
-        type: str
-    t0iface_segment_display_name:
-        description:
-            - Same as t1iface_segment_id
-            - Either this or t1iface_segment_id must be specified. If
-              both are specified, t1iface_segment_id takes precedence.
-        type: str
-    t1iface_subnets:
-        description:
-            - IP address and subnet specification for interface.
-            - Specify IP address and network prefix for interface.
-            - Required if I(t1iface_id != null).
-        type: list
+                    - State can be either 'present' or 'absent'. 'present' is
+                      used to create or update resource. 'absent' is used to
+                      delete resource.
+                    - Required if I(segp_id != null)
+                choices:
+                    - present
+                    - absent
+            tags:
+                description: Opaque identifiers meaningful to the API user.
+                type: dict
+                suboptions:
+                    scope:
+                        description: Tag scope.
+                        required: true
+                        type: str
+                    tag:
+                        description: Tag value.
+                        required: true
+                        type: str
+            edge_cluster_info:
+                description: Used to create path to edge cluster. Auto-assigned
+                             if associated enforcement-point has only one edge
+                             cluster.
+                type: dict
+                suboptions:
+                    site_id:
+                        description: site_id where edge cluster is located
+                        default: default
+                        type: str
+                    enforcementpoint_id:
+                        description: enforcementpoint_id where edge cluster is
+                                     located
+                        default: default
+                        type: str
+                    edge_cluster_id:
+                        description: ID of the edge cluster
+                        required: true
+                        type: str
+                    edge_cluster_display_name:
+                        description:
+                            - display name of the edge cluster.
+                            - Either this or edge_cluster_id must be specified.
+                              If both are specified, edge_cluster_id takes
+                              precedence
+                        type: str
+            preferred_edge_nodes_info:
+                description: Used to create paths to edge nodes. Specified edge
+                             is used as preferred edge cluster member when
+                             failover mode is set to PREEMPTIVE, not
+                             applicable otherwise.
+                type: list
+                suboptions:
+                    site_id:
+                        description: site_id where edge node is located
+                        default: default
+                        type: str
+                    enforcementpoint_id:
+                        description: enforcementpoint_id where edge node is
+                                     located
+                        default: default
+                        type: str
+                    edge_cluster_id:
+                        description: edge_cluster_id where edge node is
+                                     located
+                        required: true
+                        type: str
+                    edge_cluster_display_name:
+                        description:
+                            - display name of the edge cluster.
+                            - either this or edge_cluster_id must be specified.
+                              If both are specified, edge_cluster_id takes
+                              precedence
+                        type: str
+                    edge_node_id:
+                        description: ID of the edge node
+                        type: str
+                    edge_node_display_name:
+                        description:
+                            - Display name of the edge node.
+                            - either this or edge_node_id must be specified. If
+                              both are specified, edge_node_id takes precedence
+                        type: str
+            route_redistribution_types:
+                description: Enable redistribution of different types of routes
+                             on Tier-1.
+                choices:
+                    - TIER1_STATIC - Redistribute all subnets and static routes
+                                    advertised by Tier-1s.
+                    - TIER1_NAT - Redistribute NAT IPs advertised by Tier-1
+                                instances.
+                    - TIER1_LB_VIP - Redistribute LB VIP IPs advertised by
+                                    Tier-1 instances.
+                    - TIER1_LB_SNAT - Redistribute LB SNAT IPs advertised by
+                                    Tier-1 instances.
+                    - TIER1_DNS_FORWARDER_IP - Redistribute DNS forwarder
+                                            subnets on Tier-1 instances.
+                    - TIER1_CONNECTED - Redistribute all subnets configured on
+                                    Segments and Service Interfaces.
+                    - TIER1_SERVICE_INTERFACE - Redistribute Tier1 service
+                                            interface subnets.
+                    - TIER1_SEGMENT - Redistribute subnets configured on
+                                    Segments connected to Tier1.
+                    - TIER1_IPSEC_LOCAL_ENDPOINT - Redistribute IPSec VPN
+                                                local-endpoint  subnets
+                                                advertised by TIER1.
+                type: list
+            interfaces:
+                type: list
+                element: dict
+                description: Specify the interfaces associated with the Gateway
+                             in this section that need to be created, updated,
+                             or deleted
+                suboptions:
+                    id:
+                        description: Tier-1 Interface ID
+                        required: false
+                        type: str
+                    description:
+                        description: Tier-1 Interface  description
+                        type: str
+                    display_name:
+                        description:
+                            - Tier-1 Interface display name
+                            - Either this or id must be specified. If both are
+                              specified, id takes precedence.
+                        required: false
+                        type: str
+                    state:
+                        description:
+                            - State can be either 'present' or 'absent'.
+                              'present' is used to create or update resource.
+                              'absent' is used to delete resource.
+                            - Required if I(segp_id != null).
+                        choices:
+                            - present
+                            - absent
+                    tags:
+                        description: Opaque identifiers meaningful to the API
+                                     user
+                        type: dict
+                        suboptions:
+                            scope:
+                                description: Tag scope.
+                                required: true
+                                type: str
+                            tag:
+                                description: Tag value.
+                                required: true
+                                type: str
+                    ipv6_ndra_profile_id:
+                        description:
+                            - Configrue IPv6 NDRA profile. Only one NDRA
+                              profile can be configured
+                            - Required if I(id != null)
+                        type: str
+                    segment_id:
+                        description:
+                            - Specify Segment to which this interface is
+                              connected to.
+                            - Required if I(id != null)
+                        type: str
+                    t0iface_segment_display_name:
+                        description:
+                            - Same as segment_id
+                            - Either this or segment_id must be specified. If
+                              both are specified, segment_id takes precedence.
+                        type: str
+                    subnets:
+                        description:
+                            - IP address and subnet specification for interface
+                            - Specify IP address and network prefix for
+                              interface
+                            - Required if I(id != null)
+                        type: list
 '''
 
 EXAMPLES = '''
 - name: create Tier1
   nsxt_tier1:
-    hostname: "10.160.84.49"
-    username: "admin"
-    password: "Admin!23Admin"
+    hostname: "10.10.10.10"
+    username: "username"
+    password: "password"
     validate_certs: False
-    id: test-tier1
-    display_name: test-tier1
-    state: "present"
+    display_name: test-tier22222
+    state: present
     failover_mode: "PREEMPTIVE"
     disable_firewall: True
     force_whitelisting: True
     tags:
       - scope: "a"
-      tag: "b"
-    t1ls_id: test-t1ls
-    t1ls_state: "present"
-    t1ls_display_name: "test-t1ls"
-    t1ls_route_redistribution_types: ["TIER0_STATIC", "TIER0_NAT"]
-    t1ls_edge_cluster_info:
-      edge_cluster_id: "95196903-6b8a-4276-a7c4-387263e834fd"
-    t1ls_preferred_edge_nodes_info:
-      - edge_cluster_id: "95196903-6b8a-4276-a7c4-387263e834fd"
-        edge_id: "940f1f4b-0317-45d4-84e2-b8c2394e7405"
-    t1iface_id: "test-t0-t1ls-iface"
-    t1iface_display_name: "test-t0-t1ls-iface"
-    t1iface_state: "present"
-    t1iface_subnets:
-      - ip_addresses: ["35.1.1.1"]
-        prefix_len: 24
-    t1iface_segment_id: "sg-uplink"
+        tag: "b"
+    route_advertisement_rules:
+      - name: "test-route-advertisement-rules"
+        route_advertisement_types: ['TIER1_STATIC_ROUTES', 'TIER1_CONNECTED']
+        subnets: ["35.1.1.1/23"]
+    route_advertisement_types:
+        - "TIER1_STATIC_ROUTES"
+        - "TIER1_CONNECTED"
+        - "TIER1_NAT"
+    tier0_display_name: "node-t0"
+    locale_services:
+      - state: present
+        display_name: test-t1ls-1
+        route_redistribution_types: ["TIER0_STATIC", "TIER0_NAT"]
+      - state: present
+        display_name: test-t1ls-2
+        route_redistribution_types: ["TIER0_STATIC", "TIER0_NAT"]
+        interfaces:
+          - id: "test-t1-t1ls-iface-2"
+            display_name: "test-t1-t1ls-iface"
+            state: present
+            subnets:
+              - ip_addresses: ["35.1.1.1"]
+                prefix_len: 24
+            segment_id: "test-seg-2"
 '''
 
 RETURN = '''# '''
@@ -386,6 +412,7 @@ RETURN = '''# '''
 import json
 import time
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import _ANSIBLE_ARGS as ANSIBLE_ARGS
 from ansible.module_utils._text import to_native
 from ansible.module_utils.nsxt_base_resource import NSXTBaseRealizableResource
 
@@ -511,14 +538,14 @@ class NSXTTier1(NSXTBaseRealizableResource):
     def get_resource_base_url(baseline_args=None):
         return '/infra/tier-1s'
 
-    def update_resource_params(self):
+    def update_resource_params(self, nsx_resource_params):
         ipv6_profile_paths = []
         if self.do_resource_params_have_attr_with_id_or_display_name(
                 "ipv6_ndra_profile"):
             ipv6_ndra_profile_base_url = (PolicyIpv6NdraProfiles.
                                           get_resource_base_url())
             ipv6_ndra_profile_id = self.get_id_using_attr_name_else_fail(
-                    "ipv6_ndra_profile", self.resource_params,
+                    "ipv6_ndra_profile", nsx_resource_params,
                     ipv6_ndra_profile_base_url, "Ipv6NdraProfile")
             ipv6_profile_paths.append(
                 ipv6_ndra_profile_base_url + "/" + ipv6_ndra_profile_id)
@@ -527,42 +554,42 @@ class NSXTTier1(NSXTBaseRealizableResource):
             ipv6_dad_profile_base_url = (PolicyIpv6DadProfiles.
                                          get_resource_base_url())
             ipv6_dad_profile_id = self.get_id_using_attr_name_else_fail(
-                    "ipv6_dad_profile", self.resource_params,
+                    "ipv6_dad_profile", nsx_resource_params,
                     ipv6_dad_profile_base_url, "Ipv6DadProfile")
             ipv6_profile_paths.append(
                 ipv6_dad_profile_base_url + "/" + ipv6_dad_profile_id)
         if ipv6_profile_paths:
-            self.resource_params["ipv6_profile_paths"] = ipv6_profile_paths
+            nsx_resource_params["ipv6_profile_paths"] = ipv6_profile_paths
 
         if self.do_resource_params_have_attr_with_id_or_display_name(
                 "dhcp_config"):
             dhcp_config_base_url = (
                 PolicyDhcpRelayConfig.get_resource_base_url())
             dhcp_config_id = self.get_id_using_attr_name_else_fail(
-                "dhcp_config", self.resource_params,
+                "dhcp_config", nsx_resource_params,
                 dhcp_config_base_url, "DhcpRelayConfig")
-            self.resource_params["dhcp_config_paths"] = [
+            nsx_resource_params["dhcp_config_paths"] = [
                 dhcp_config_base_url + "/" + dhcp_config_id]
 
         if self.do_resource_params_have_attr_with_id_or_display_name(
                 "tier0"):
             tier0_base_url = NSXTTier0.get_resource_base_url()
             tier0_id = self.get_id_using_attr_name_else_fail(
-                "tier0", self.resource_params,
+                "tier0", nsx_resource_params,
                 tier0_base_url, "Tier0")
-            self.resource_params["tier0_path"] = (
+            nsx_resource_params["tier0_path"] = (
                 tier0_base_url + "/" + tier0_id)
 
     def update_parent_info(self, parent_info):
         parent_info["tier1_id"] = self.id
 
     class NSXTTier1LocaleService(NSXTBaseRealizableResource):
-        def get_unique_arg_identifier(self):
-            return NSXTTier1.NSXTTier1LocaleService.get_unique_arg_identifier()
+        def get_spec_identifier(self):
+            return NSXTTier1.NSXTTier1LocaleService.get_spec_identifier()
 
-        @staticmethod
-        def get_unique_arg_identifier():
-            return "t1ls"
+        @classmethod
+        def get_spec_identifier(cls):
+            return "locale_services"
 
         @staticmethod
         def get_resource_spec():
@@ -630,9 +657,9 @@ class NSXTTier1(NSXTBaseRealizableResource):
             tier1_id = parent_info.get("tier1_id", 'default')
             return '/infra/tier-1s/{}/locale-services'.format(tier1_id)
 
-        def update_resource_params(self):
-            if "edge_cluster_info" in self.resource_params:
-                edge_cluster_info = self.resource_params.pop(
+        def update_resource_params(self, nsx_resource_params):
+            if "edge_cluster_info" in nsx_resource_params:
+                edge_cluster_info = nsx_resource_params.pop(
                     "edge_cluster_info")
                 site_id = edge_cluster_info["site_id"]
                 enforcementpoint_id = edge_cluster_info["enforcementpoint_id"]
@@ -642,13 +669,13 @@ class NSXTTier1(NSXTBaseRealizableResource):
                 edge_cluster_id = self.get_id_using_attr_name_else_fail(
                     "edge_cluster", edge_cluster_info, edge_cluster_base_url,
                     PolicyEdgeCluster.__name__)
-                self.resource_params["edge_cluster_path"] = (
+                nsx_resource_params["edge_cluster_path"] = (
                     edge_cluster_base_url + "/" + edge_cluster_id)
 
-            if "preferred_edge_nodes_info" in self.resource_params:
-                preferred_edge_nodes_info = self.resource_params.pop(
+            if "preferred_edge_nodes_info" in nsx_resource_params:
+                preferred_edge_nodes_info = nsx_resource_params.pop(
                     "preferred_edge_nodes_info")
-                self.resource_params["preferred_edge_paths"] = []
+                nsx_resource_params["preferred_edge_paths"] = []
                 for preferred_edge_node_info in preferred_edge_nodes_info:
                     site_id = preferred_edge_node_info.get(
                         "site_id", "default")
@@ -665,20 +692,20 @@ class NSXTTier1(NSXTBaseRealizableResource):
                     edge_node_id = self.get_id_using_attr_name_else_fail(
                         "edge_node", preferred_edge_node_info,
                         edge_node_base_url, PolicyEdgeNode.__name__)
-                    self.resource_params["preferred_edge_paths"].append(
+                    nsx_resource_params["preferred_edge_paths"].append(
                         edge_node_base_url + "/" + edge_node_id)
 
         def update_parent_info(self, parent_info):
-            parent_info["t1ls_id"] = self.id
+            parent_info["id"] = self.id
 
         class NSXTTier1Interface(NSXTBaseRealizableResource):
-            def get_unique_arg_identifier(self):
+            def get_spec_identifier(self):
                 return (NSXTTier1.NSXTTier1LocaleService.NSXTTier1Interface
-                        .get_unique_arg_identifier())
+                        .get_spec_identifier())
 
-            @staticmethod
-            def get_unique_arg_identifier():
-                return "t1iface"
+            @classmethod
+            def get_spec_identifier(cls):
+                return "interfaces"
 
             @staticmethod
             def get_resource_spec():
@@ -706,18 +733,18 @@ class NSXTTier1(NSXTBaseRealizableResource):
             @staticmethod
             def get_resource_base_url(parent_info):
                 tier1_id = parent_info.get("tier1_id", 'default')
-                locale_service_id = parent_info.get("t1ls_id", 'default')
+                locale_service_id = parent_info.get("id", 'default')
                 return ('/infra/tier-1s/{}/locale-services/{}/interfaces'
                         .format(tier1_id, locale_service_id))
 
-            def update_resource_params(self):
+            def update_resource_params(self, nsx_resource_params):
                 # segment_id is a required attr
                 segment_base_url = NSXTSegment.get_resource_base_url()
                 segment_id = self.get_id_using_attr_name_else_fail(
-                    "segment", self.resource_params,
+                    "segment", nsx_resource_params,
                     segment_base_url,
                     "Segment")
-                self.resource_params["segment_path"] = (
+                nsx_resource_params["segment_path"] = (
                     segment_base_url + "/" + segment_id)
 
                 if self.do_resource_params_have_attr_with_id_or_display_name(
@@ -726,9 +753,9 @@ class NSXTTier1(NSXTBaseRealizableResource):
                         PolicyIpv6NdraProfiles.get_resource_base_url())
                     ipv6_ndra_profile_id = (
                         self.get_id_using_attr_name_else_fail(
-                            "ipv6_ndra_profile", self.resource_params,
+                            "ipv6_ndra_profile", nsx_resource_params,
                             ipv6_ndra_profile_url, "Ipv6 NDRA Profile"))
-                    self.resource_params["ipv6_profile_paths"] = [
+                    nsx_resource_params["ipv6_profile_paths"] = [
                         ipv6_ndra_profile_url + "/" + ipv6_ndra_profile_id]
 
 


### PR DESCRIPTION
Until now, user had to prepent a prefix to specify any subresource
spec in the playbook. This limited the user's scope to specify only
1 subresource. However, it is possible that 2 or more subresources
can be associated with a single resource. This change
modifies the behavior in a way that the user can specify multiple
subresources under its respective section, which is clear from the
Ansible Module's doc.

Additionally, there are some speed enhancements:
1. We no longer create an Ansible Module for each subresource
2. We no longer test and create Ansible Module to infer which
   resources are specified by the user at runtime. This is possible
   with the help of using spec_identifiers

Lastly, using spec_identifiers improves the code readability as well
as user experience.

Issue: #123

Signed-off-by: Gautam Verma <vermag@vmware.com>
Signed-off-by: Gautam Verma <gautam94verma@gmail.com>