### PR TITLE
Fix: Make id or display_name optional but either to be present

### DIFF
--- a/policy-ansible-for-nsxt/module_utils/nsxt_base_resource.py
+++ b/policy-ansible-for-nsxt/module_utils/nsxt_base_resource.py
@@ -399,7 +399,7 @@ class NSXTBaseRealizableResource(ABC):
             module = AnsibleModule(argument_spec=self._arg_spec,
                                    supports_check_mode=supports_check_mode)
 
-            if not (module.params['id'] and module.params['display_name']):
+            if not (module.params['id'] or module.params['display_name']):
                 module.fail_json(
                     msg="Please specify either id or display_name of the "
                         "resource")

--- a/policy-ansible-for-nsxt/tests/unit/module_utils/test_nsxt_base_resource.py
+++ b/policy-ansible-for-nsxt/tests/unit/module_utils/test_nsxt_base_resource.py
@@ -22,27 +22,10 @@ import unittest
 import json
 from unittest.mock import Mock, patch
 
-from shutil import copyfile
-import ansible.module_utils.basic as ansible_basic
-
-# Copy policy_communicator.py to ansibles' module_utils to test.
-import os
-path_policy_ansible_lib = os.getcwd()
-path_ansible_lib = os.path.dirname(
-    os.path.abspath(ansible_basic.__file__)) + "/../"
-policy_communicator_file = (
-    path_policy_ansible_lib + "/module_utils/policy_communicator.py")
-
-copyfile(policy_communicator_file,
-         path_ansible_lib + "module_utils/policy_communicator.py")
-
-# now import it
+# In order to test, you need to export the PYTHONPATH so that it can find
+# these py modules
 import module_utils.nsxt_base_resource as nsxt_base_resource
-from ansible.module_utils.policy_communicator import PolicyCommunicator
-
-# then delete it from ansible's module_utils
-os.remove(path_ansible_lib + "module_utils/policy_communicator.py")
-
+from module_utils.policy_communicator import PolicyCommunicator
 
 class SimpleDummyNSXTResource(nsxt_base_resource.NSXTBaseRealizableResource):
     def __init__(self):


### PR DESCRIPTION
Also, fix imports in pytest in that python path must be exported
in order to run the tests. This allows not to copy the modules
to ansible directory

Signed-off-by: Gautam Verma <vermag@vmware.com>
Signed-off-by: Gautam Verma <gautam94verma@gmail.com>