### PR TITLE
Add support for vrf_config in tier0

### DIFF
--- a/policy-ansible-for-nsxt/README.md
+++ b/policy-ansible-for-nsxt/README.md
@@ -18,6 +18,7 @@ Please note that you must specify the correct vmware args in order to successful
    3. Tier-0 Interface
    4. Tier-0 BGP
    5. Tier-0 BGP Neighbors
+   6. Tier-0 VRF
 2. Tier-1 Gateway
    1. Tier-1 Locale Services
    2. Tier-1 Static Routes

--- a/policy-ansible-for-nsxt/module_utils/nsxt_base_resource.py
+++ b/policy-ansible-for-nsxt/module_utils/nsxt_base_resource.py
@@ -321,6 +321,9 @@ class NSXTBaseRealizableResource(ABC):
                               " for the resource {}".format(
                                   attr_name, str(resource_type)))
 
+    def exit_with_failure(self, msg, **kwargs):
+        self.module.fail_json(msg=msg, **kwargs)
+
     def skip_delete(self):
         """
         Override in subclass if this resource is skipped to be deleted.

--- a/policy-ansible-for-nsxt/unit_tests/test_nsxt_tier0.yml
+++ b/policy-ansible-for-nsxt/unit_tests/test_nsxt_tier0.yml
@@ -63,11 +63,11 @@
                   remote_as_num: "12"
                   state: present
             interfaces:
-                - display_name: neigh2
-                  neighbor_address: "1.2.3.5"
-                  password: "myPassword"
-                  remote_as_num: "22"
-                  state: present
+              - display_name: neigh2
+                neighbor_address: "1.2.3.5"
+                password: "myPassword"
+                remote_as_num: "22"
+                state: present
               - id: "test-t0-t0ls-iface"
                 display_name: "test-t0-t0ls-iface"
                 state: present
@@ -78,3 +78,12 @@
                 edge_node_info:
                   edge_cluster_id: "7ef91a10-c780-4f48-a279-a5662db4ffa3"
                   edge_node_id: "e10c42dc-db27-11e9-8cd0-000c291af7ee"
+        vrf_config:
+          display_name: my-vrf
+          id: my-vrf2
+          tier0_display_name: node-t0
+          tags:
+            - scope: scope-tag-1
+              tag: value-tag-1
+          route_distinguisher: 'ASN:4000'
+          evpn_transit_vni: 6000


### PR DESCRIPTION
We reuse the nsxt_tier0 module to add the support to configure
the vrf_config on a tier0 router

Jira: #50034

Signed-off-by: Gautam Verma <vermag@vmware.com>
Signed-off-by: Gautam Verma <gautam94verma@gmail.com>