### PR TITLE
Description field in nsxt_uplink_profiles

### DIFF
--- a/library/nsxt_uplink_profiles.py
+++ b/library/nsxt_uplink_profiles.py
@@ -46,6 +46,10 @@ options:
         description: Display name
         required: true
         type: str
+    description:
+        description: Description of the resource
+        required: false
+        type: str
     enabled:
         description: 'The enabled property specifies the status of NIOC feature.
                       When enabled is set to true, NIOC feature is turned on and


### PR DESCRIPTION
Description field was not present in nsxt_uplink_profiles
module. The support for the field is added now in the
module. This solves bugzilla #2509025.

Signed-off-by: Kommireddy Akhilesh<akhileshk@vmware.com>