### PR TITLE
Transport zone update

### DIFF
--- a/library/nsxt_transport_zones.py
+++ b/library/nsxt_transport_zones.py
@@ -158,8 +158,11 @@ def check_for_update(module, manager_url, mgr_username, mgr_password, validate_c
     existing_transport_zone = get_tz_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, transport_zone_params['display_name'])
     if existing_transport_zone is None:
         return False
-    if existing_transport_zone.__contains__('transport_type') and transport_zone_params.__contains__('transport_type') and \
-        existing_transport_zone['transport_type'] != transport_zone_params['transport_type']:
+    if existing_transport_zone.__contains__('is_default') and transport_zone_params.__contains__('is_default') and \
+        existing_transport_zone['is_default'] != transport_zone_params['is_default']:
+        return True
+    if existing_transport_zone.__contains__('description') and transport_zone_params.__contains__('description') and \
+        existing_transport_zone['description'] != transport_zone_params['description']:
         return True
     return False
 


### PR DESCRIPTION
Transport zone update was failing even when description was
being changed. This was due to incorrect way of checking for
update. It is fixed now. This solves bugzilla #2508917

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>