### PR TITLE
Renaming auto_deployment modules

### DIFF
--- a/library/nsxt_manager_auto_deployment.py
+++ b/library/nsxt_manager_auto_deployment.py
@@ -20,7 +20,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: nsxt_controller_manager_auto_deployment
+module: nsxt_manager_auto_deployment
 short_description: 'Deploy and register a cluster node VM'
 description: "Deploys a cluster node VM as specified by the deployment config.
               Once the VM is deployed and powered on, it will automatically join the
@@ -61,7 +61,7 @@ options:
 
 EXAMPLES = '''
   - name: Deploy and register a cluster node VM
-    nsxt_manager_controllers:
+    nsxt_manager_auto_deployment:
       hostname: "10.192.167.137"
       username: "admin"
       password: "Admin!23Admin"

--- a/library/nsxt_manager_auto_deployment_facts.py
+++ b/library/nsxt_manager_auto_deployment_facts.py
@@ -19,7 +19,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 
 DOCUMENTATION = '''
-module: nsxt_controller_manager_auto_deployment_facts
+module: nsxt_manager_auto_deployment_facts
 short_description: 'Returns info for all cluster node VM auto-deployment attempts'
 description: 'Returns request information for every attempted deployment of a 
               cluster node VM'
@@ -41,7 +41,7 @@ options:
 '''
 
 EXAMPLES = '''
-- nsxt_controller_manager_auto_deployment_facts:
+- nsxt_manager_auto_deployment_facts:
       hostname: "10.192.167.137"
       username: "admin"
       password: "Admin!23Admin"

--- a/test_controller_manager_auto_deployment.yml
+++ b/test_controller_manager_auto_deployment.yml
@@ -5,7 +5,7 @@
     - answerfile.yml
   tasks:
     - name: Deploy and register a cluster node VM
-      nsxt_controller_manager_auto_deployment:
+      nsxt_manager_auto_deployment:
           hostname: "{{hostname}}"
           username: "{{username}}"
           password: "{{password}}"

--- a/test_controller_manager_auto_deployment_facts.yml
+++ b/test_controller_manager_auto_deployment_facts.yml
@@ -5,7 +5,7 @@
     - answerfile.yml
   tasks:
     - name: Lists info for all cluster node VM auto-deployment
-      nsxt_controller_manager_auto_deployment_facts:
+      nsxt_manager_auto_deployment_facts:
           hostname: "{{hostname}}"
           username: "{{username}}"
           password: "{{password}}"


### PR DESCRIPTION
Autodeployment modules of have been renamed
nsxt_controller_manager_auto_deployment is changed to
nsxt_manager_auto_deployment.
nsxt_controller_manager_auto_deployment_facts is changed
to nsx_manager_auto_deployment_facts.
This solves bugzilla 2510151

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>