### PR TITLE
Compatibility python 3.6

### DIFF
--- a/library/nsxt_fabric_compute_managers.py
+++ b/library/nsxt_fabric_compute_managers.py
@@ -212,7 +212,9 @@ def check_for_update(module, manager_url, mgr_username, mgr_password, validate_c
     if existing_compute_manager is None:
         return False
     if existing_compute_manager['server'] != compute_manager_with_ids['server'] or \
-        existing_compute_manager['credential']['thumbprint'] != compute_manager_with_ids['credential']['thumbprint']:
+        existing_compute_manager['credential']['thumbprint'] != compute_manager_with_ids['credential']['thumbprint'] or \
+        existing_compute_manager['origin_type'] != compute_manager_with_ids['origin_type'] or \
+        existing_compute_manager['description'] != compute_manager_with_ids['description']:
         return True
     return False
 
@@ -228,6 +230,7 @@ def main():
                     credential_key=dict(required=False, type='str', no_log=True),
                     credential_type=dict(required=True, type='str')),
                     origin_type=dict(required=True, type='str'),
+                    description=dict(required=True, type='str'),
                     server=dict(required=True, type='str'),
                     state=dict(required=True, choices=['present', 'absent']))
 

--- a/module_utils/vmware_nsxt.py
+++ b/module_utils/vmware_nsxt.py
@@ -47,7 +47,7 @@ def request(url, data=None, headers=None, method='GET', use_proxy=True,
                      url_username=url_username, url_password=url_password, http_agent=http_agent,
                      client_cert=client_cert, force_basic_auth=force_basic_auth)
     except HTTPError as err:
-        r = err.fp
+        r = err
 
     try:
         raw_data = r.read()


### PR DESCRIPTION
Delete task of nsxt_fabric_compute_manager was failing as
error code was not being returned was not caught in
python 3.6. The issue is solved now.

This was the reason that update failed as response returned
was '' rather than dict.

Added support for description parameter.

This solves bugzilla #2508958, #2510222, #251023

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>