### PR TITLE
Transport zone endpoint in host switch

### DIFF
--- a/library/nsxt_transport_node_profiles.py
+++ b/library/nsxt_transport_node_profiles.py
@@ -77,7 +77,7 @@ options:
         required: true
     transport_zone_endpoints:
         description: Transport zone endpoints.
-        required: true
+        required: False
         type: array of TransportZoneEndPoint
     
 '''
@@ -105,8 +105,8 @@ EXAMPLES = '''
         ip_assignment_spec:
           resource_type: "StaticIpPoolSpec"
           ip_pool_name: "IPPool-IPV4-1"
-    transport_zone_endpoints:
-    - transport_zone_name: "TZ1"
+        transport_zone_endpoints:
+        - transport_zone_name: "TZ1"
     state: "present"
 
 '''
@@ -178,6 +178,12 @@ def update_params_with_id (module, manager_url, mgr_username, mgr_password, vali
             host_switch['ip_assignment_spec']['ip_pool_id'] = get_id_from_display_name (module, manager_url,
                                                                                         mgr_username, mgr_password, validate_certs,
                                                                                         "/pools/ip-pools", ip_pool_name)
+        if host_switch.__contains__('transport_zone_endpoints'):
+            for transport_zone_endpoint in host_switch['transport_zone_endpoints']:
+                transport_zone_name = transport_zone_endpoint.pop('transport_zone_name', None)
+                transport_zone_endpoint['transport_zone_id'] = get_id_from_display_name (module, manager_url,
+                                                                                    mgr_username, mgr_password, validate_certs,
+                                                                                    "/transport-zones", transport_zone_name)
     if transport_node_profile_params.__contains__('transport_zone_endpoints'):
         for transport_zone_endpoint in transport_node_profile_params['transport_zone_endpoints']:
             transport_zone_name = transport_zone_endpoint.pop('transport_zone_name', None)
@@ -224,7 +230,7 @@ def main():
                 host_switches=dict(required=True, type='list'),
                 resource_type=dict(required=True, type='str')),
                 resource_type=dict(required=True, type='str'),
-                transport_zone_endpoints=dict(required=True, type='list'),
+                transport_zone_endpoints=dict(required=False, type='list'),
                 state=dict(required=True, choices=['present', 'absent']))
 
   module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)


### PR DESCRIPTION
NSX Grindcore supports parameter transport_zone_endpoint
inside host_switch spec. This caused ansible break.
This PR gives support for the transport_zone_endpoint
parameter.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>