### PR TITLE
nsxt_uplink_profiles failing

### DIFF
--- a/library/nsxt_uplink_profiles.py
+++ b/library/nsxt_uplink_profiles.py
@@ -112,21 +112,6 @@ options:
             required: true
             type: array of Uplink
         description: Default TeamingPolicy associated with this UplinkProfile
-        name:
-            description: An uplink teaming policy of a given name defined in UplinkHostSwitchProfile.
-                         The names of all NamedTeamingPolicies in an UplinkHostSwitchProfile 
-                         must be different, but a name can be shared by different
-                         UplinkHostSwitchProfiles. Different TransportNodes can use different 
-                         NamedTeamingPolicies having the same name in different 
-                         UplinkHostSwitchProfiles to realize an uplink teaming policy on a
-                         logical switch. An uplink teaming policy on a logical switch can be any
-                         policy defined by a user; it does not have to be a single type of FAILOVER
-                         or LOADBALANCE. It can be a combination of types, for instance, a user can 
-                         define a policy with name "MyHybridTeamingPolicy" as "FAILOVER on all ESX 
-                         TransportNodes and LOADBALANCE on all KVM TransportNodes". The name is the 
-                         key of the teaming policy and can not be changed once assigned.
-            required: true
-            type: str
         policy:
             description: Teaming policy
             required: true
@@ -223,7 +208,6 @@ def main():
                         teaming=dict(required=True, type='dict',
                         policy=dict(required=True, type='str'),
                         standby_list=dict(required=False, type='list'),
-                        name=dict(required=True, type='str'),
                         active_list=dict(required=True, type='list')),
                         lags=dict(required=False, type='list'),
                         resource_type=dict(required=True, type='str', choices=['UplinkHostSwitchProfile']),


### PR DESCRIPTION
Name field in teaming is not supported anymore. To add multiple
modules we use named_teaming option. Using name field throws
error from the Json error from manager. Thus removing the
field now. This solves bugzilla 2516146

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>