### PR TITLE
Existing transport zone update

### DIFF
--- a/library/nsxt_transport_zones.py
+++ b/library/nsxt_transport_zones.py
@@ -171,7 +171,7 @@ def check_for_update(module, manager_url, mgr_username, mgr_password, validate_c
     if not existing_transport_zone.__contains__('uplink_teaming_policy_names') and transport_zone_params.__contains__('uplink_teaming_policy_names'):
         return True
     if existing_transport_zone.__contains__('uplink_teaming_policy_names') and transport_zone_params.__contains__('uplink_teaming_policy_names') and \
-        existing_transport_zone['uplink_teaming_policy_names'] != existing_transport_zone['uplink_teaming_policy_names']:
+        existing_transport_zone['uplink_teaming_policy_names'] != transport_zone_params['uplink_teaming_policy_names']:
         return True
     return False
 


### PR DESCRIPTION
Uplink teaming policy names field was unable to update to a
typing mistake in previous CL. The comparision was not done correctly.
During update existing_transport_zone was being compared with
existing_transport_zone. Corrected the issue now. Comparing
existing_transport_zone with transport_zone_params.
Tested: uplink teaming_policy_names are updated successfully.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>