### PR TITLE
Note for special characters in password

### DIFF
--- a/library/nsxt_fabric_compute_managers.py
+++ b/library/nsxt_fabric_compute_managers.py
@@ -60,7 +60,9 @@ options:
         description: 'Login credentials for the compute manager'
         password:
             description: "Password for the user (optionally specified on PUT, unspecified on
-                          GET)"
+                          GET). Please take care of the special characters while providing
++                         password. Like if password contains '$' and if you are passing through
++                         command line, then you got to use \$ instead." 
             no_log: 'True'
             required: false
             type: str


### PR DESCRIPTION
When using special characters in password of compute manager
and passing through command line, special characters may be
interpreted differently by the bash and provide wrong
password to the ansible module causing failure. Added a note in
the documentation regarding this issue.
This solves bugzilla: 2515487

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>