### PR TITLE
Add missing attrs in policy_group and securty_policy

### DIFF
--- a/policy-ansible-for-nsxt/library/nsxt_policy_group.py
+++ b/policy-ansible-for-nsxt/library/nsxt_policy_group.py
@@ -47,7 +47,7 @@ options:
         type: str
     expression:
         description:
-            - The expression list must follow below criteria:
+            - The expression list must follow below criteria
                 - 1. A non-empty expression list, must be of odd size.
                   In a list, with indices starting from 0, all
                   non-conjunction expressions must be at
@@ -62,7 +62,35 @@ options:
                 - 4. Each expression must be a valid Expression. See
                   the definition of the Expression type for more
                   information.
+        type: list
+    extended_expression:
+        description:
+            - Extended Expression allows additional higher level context to be
+              specified for grouping criteria (e.g. user AD group). This field
+              allow users to specified user context as the source of a firewall
+              rule for IDFW feature.  Current version only support a single
+              IdentityGroupExpression. In the future, this might expand to
+              support other conjunction and non-conjunction expression.
+            - The extended expression list must follow below criteria
+                - 1. Contains a single IdentityGroupExpression. No conjunction
+                  expression is supported
+                - 2. No other non-conjunction expression is supported, except
+                  for IdentityGroupExpression
+                - 3. Each expression must be a valid Expression. See the
+                  definition of the Expression type for more information
+                - 4. Extended expression are implicitly AND with expression
+                - 5. No nesting can be supported if this value is used
+                - 6. If a Group is using extended expression, this group must
+                  be the only member in the source field of an communication
+                  map
+        type: list
+    group_state:
+        description: Realization state of this group
         type: str
+        choices:
+            - IN_PROGRESS
+            - SUCCESS
+            - FAILURE
 '''
 
 EXAMPLES = '''
@@ -106,7 +134,15 @@ class NSXTPolicyGroup(NSXTBaseRealizableResource):
             expression=dict(
                 required=True,
                 type='list'
-            )
+            ),
+            extended_expression=dict(
+                required=False,
+                type='list'
+            ),
+            group_state=dict(
+                required=False,
+                type='str'
+            ),
         )
         return policy_group_arg_spec
 

--- a/policy-ansible-for-nsxt/library/nsxt_security_policy.py
+++ b/policy-ansible-for-nsxt/library/nsxt_security_policy.py
@@ -84,6 +84,30 @@ options:
     comments:
         type: str
         description: SecurityPolicy lock/unlock comments
+    connectivity_strategy:
+        type: str
+        description:
+            - Connectivity strategy applicable for this SecurityPolicy
+            - This field indicates the default connectivity policy for the
+              security policy. Based on the connectivitiy strategy, a default
+              rule for this security policy will be created. An appropriate
+              action will be set on the rule based on the value of the
+              connectivity strategy. If NONE is selected or no connectivity
+              strategy is specified, then no default rule for the security
+              policy gets created. The default rule that gets created will be a
+              any-any rule and applied to entities specified in the scope of
+              the security policy. Specifying the connectivity_strategy without
+              specifying the scope is not allowed. The scope has to be a
+              Group and one cannot specify IPAddress directly in the group that
+              is used as scope. This default rule is only applicable for the
+              Layer3 security policies
+            - WHITELIST - Adds a default drop rule. Administrator can then use
+              "allow" rules (aka whitelist) to allow traffic between groups
+            - BLACKLIST - Adds a default allow rule. Admin can then use "drop"
+              rules (aka blacklist) to block traffic between groups
+            - WHITELIST_ENABLE_LOGGING - Whitelising with logging enabled
+            - BLACKLIST_ENABLE_LOGGING - Blacklisting with logging enabled
+            - NONE - No default rule is created
     locked:
         type: bool
         description:
@@ -247,6 +271,12 @@ class NSXTSecurityPolicy(NSXTBaseRealizableResource):
             comments=dict(
                 required=False,
                 type='str'
+            ),
+            connectivity_strategy=dict(
+                required=False,
+                type='str',
+                choices=['WHITELIST', 'BLACKLIST', 'WHITELIST_ENABLE_LOGGING',
+                         'BLACKLIST_ENABLE_LOGGING', 'NONE']
             ),
             domain_id=dict(
                 required=True,


### PR DESCRIPTION
These attributes can be provided by the user to configure the
resources on NSX and hence must be included.