### PR TITLE
Add missing attrs in nsxt_segment and seg_ports

### DIFF
--- a/policy-ansible-for-nsxt/library/nsxt_segment.py
+++ b/policy-ansible-for-nsxt/library/nsxt_segment.py
@@ -43,6 +43,108 @@ options:
     description:
         description: Segment description.
         type: str
+    address_bindings:
+        description: Address bindings for the Segment
+        type: list
+        elements: dict
+        suboptions:
+            ip_address:
+                description: IP Address for port binding
+                type: str
+            mac_address:
+                description: Mac address for port binding
+                type: str
+            vlan_id:
+                description: VLAN ID for port binding
+                type: int
+    advanced_config:
+        description: Advanced configuration for Segment.
+        type: dict
+        suboptions:
+            address_pool_display_name:
+                description:
+                    - IP address pool display name
+                    - Either this or address_pool_id must be specified. If both
+                      are specified, address_pool_id takes precedence
+                type: str
+            address_pool_id:
+                description:
+                    - IP address pool ID
+                    - Either this or address_pool_display_name must be
+                      specified. If both are specified, address_pool_id takes
+                      precedence
+                type: str
+            connectivity:
+                description: Connectivity configuration to manually connect
+                             (ON) or disconnect (OFF) a logical entity from
+                             network topology. Only valid for Tier1 Segment
+                type: str
+            hybrid:
+                description:
+                    - Flag to identify a hybrid logical switch
+                    - When set to true, all the ports created on this segment
+                      will behave in a hybrid fashion. The hybrid port
+                      indicates to NSX that the VM intends to operate in
+                      underlay mode, but retains the ability to forward egress
+                      traffic to the NSX overlay network. This property is only
+                      applicable for segment created with transport zone type
+                      OVERLAY_STANDARD. This property cannot be modified after
+                      segment is created.
+                type: bool
+            local_egress:
+                description:
+                    - Flag to enable local egress
+                    - This property is used to enable proximity routing with
+                      local egress. When set to true, logical router interface
+                      (downlink) connecting Segment to Tier0/Tier1 gateway is
+                      configured with prefix-length 32.
+                type: bool
+            local_egress_routing_policies:
+                description: An ordered list of routing policies to forward
+                             traffic to the next hop.
+                type: list
+                elements: dict
+                suboptions:
+                    nexthop_address:
+                        required: true
+                        description: Next hop address for proximity routing
+                        type: str
+                    prefix_list_paths:
+                        required: true
+                        description:
+                            - Policy path to prefix lists
+                            - max 1 element
+                            - The destination address of traffic matching a
+                              prefix-list is forwarded to the nexthop_address.
+                              Traffic matching a prefix list with Action DENY
+                              will be dropped. Individual prefix-lists
+                              specified could have different actions.
+                        type: list
+                        elements: str
+            multicast:
+                description:
+                    - Enable multicast on the downlink
+                    - Enable multicast for a segment. Only applicable for
+                      segments connected to Tier0 gateway.
+                type: bool
+            uplink_teaming_policy_name:
+                description:
+                    - Uplink Teaming Policy Name
+                    - The name of the switching uplink teaming policy for the
+                      Segment. This name corresponds to one of the switching
+                      uplink teaming policy names listed in TransportZone
+                      associated with the Segment. When this property is
+                      not specified, the segment will not have a teaming policy
+                      associated with it and the host switch's default teaming
+                      policy will be used by MP.
+                type: str
+    replication_mode:
+        description: Replication mode of the Segment
+        type: str
+        default: MTEP
+        choices:
+            - MTEP
+            - SOURCE
     tier0_id:
         description: The Uplink of the Policy Segment.
                      Mutually exclusive with tier_1_id.
@@ -121,8 +223,8 @@ options:
             display_name:
                 description:
                     - Segment Port display name.
-                    - Either this or     id must be specified. If both are
-                      specified,     id takes precedence.
+                    - Either this or id must be specified. If both are
+                      specified, id takes precedence.
                 required: false
                 type: str
             description:
@@ -204,6 +306,64 @@ options:
                             - PARENT
                             - CHILD
                             - INDEPENDENT
+            extra_configs:
+                description:
+                    - Extra configs on segment port
+                    - This property could be used for vendor specific
+                      configuration in key value string pairs. Segment port
+                      setting will override segment setting if the same key was
+                      set on both segment and segment port.
+                type: list
+                element: dict
+                suboptions:
+                    config_pair:
+                        description: Key value pair in string for the
+                                     configuration
+                        type: dict
+                        required: true
+                        suboptions:
+                            key:
+                                description: Key
+                                type: str
+                                required: true
+                            value:
+                                description: Value
+                                type: str
+                                required: true
+            ignored_address_bindings:
+                description:
+                    - Address bindings to be ignored by IP Discovery module
+                      IP Discovery module uses various mechanisms to discover
+                      address bindings being used on each segment port. If a
+                      user would like to ignore any specific discovered address
+                      bindings or prevent the discovery of a particular set of
+                      discovered bindings, then those address bindings can be
+                      provided here. Currently IP range in CIDR format is not
+                      supported.
+                type: dict
+                suboptions:
+                ip_address:
+                    description: IP Address for port binding.
+                    type: str
+                mac_address:
+                    description: Mac address for port binding.
+                    type: str
+                vlan_id:
+                    description: VLAN ID for port binding.
+                    type: str
+            init_state:
+                description:
+                    - Initial state of this logical ports
+                    - Set initial state when a new logical port is created.
+                      'UNBLOCKED_VLAN' means new port will be unblocked on
+                      traffic in creation, also VLAN will be set with
+                      corresponding logical switch setting. This port setting
+                      can only be configured at port creation, and cannot be
+                      modified.
+                type: str
+                choices:
+                    - UNBLOCKED_VLAN
+                default: UNBLOCKED_VLAN
 '''
 
 EXAMPLES = '''
@@ -217,11 +377,28 @@ EXAMPLES = '''
     state: present
     domain_name: dn1
     transport_zone_display_name: "1-transportzone-730"
+    replication_mode: "SOURCE"
+    address_bindings:
+      - ip_address: "10.1.2.11"
+    advanced_config:
+      address_pool_display_name: small-2-pool
+      connectivity: "OFF"
+      hybrid: True
+      local_egress: True
     subnets:
       - gateway_address: "40.1.1.1/16"
     segment_ports:
       - display_name: test-sp-1
         state: present
+        tags:
+          - scope: "scope-1"
+            tag: "tag-2"
+        extra_configs:
+          - config_pair:
+              key: key
+              value: value
+        ignored_address_bindings:
+          - ip_address: "10.1.2.122"
       - display_name: test-sp-2
         state: present
       - display_name: test-sp-3
@@ -235,7 +412,8 @@ import time
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.nsxt_base_resource import NSXTBaseRealizableResource
 from ansible.module_utils.nsxt_resource_urls import (
-    SEGMENT_PORT_URL, SEGMENT_URL, TIER_0_URL, TIER_1_URL, TRANSPORT_ZONE_URL)
+    SEGMENT_PORT_URL, SEGMENT_URL, TIER_0_URL, TIER_1_URL, TRANSPORT_ZONE_URL,
+    IP_POOL_URL)
 from ansible.module_utils._text import to_native
 
 
@@ -244,9 +422,87 @@ class NSXTSegment(NSXTBaseRealizableResource):
     def get_resource_spec():
         segment_arg_spec = {}
         segment_arg_spec.update(
+            address_bindings=dict(
+                required=False,
+                type='list',
+                elements='dict',
+                options=dict(
+                    ip_address=dict(
+                        required=False,
+                        type='str'
+                    ),
+                    mac_address=dict(
+                        required=False,
+                        type='str'
+                    ),
+                    vlan_id=dict(
+                        required=False,
+                        type='int'
+                    )
+                )
+            ),
+            advanced_config=dict(
+                required=False,
+                type='dict',
+                options=dict(
+                    address_pool_id=dict(
+                        required=False,
+                        type='str'
+                    ),
+                    address_pool_display_name=dict(
+                        required=False,
+                        type='str'
+                    ),
+                    connectivity=dict(
+                        default="ON",
+                        type='str',
+                        choices=["ON", "OFF"],
+                    ),
+                    hybrid=dict(
+                        required=False,
+                        type='bool',
+                        default=False
+                    ),
+                    local_egress=dict(
+                        required=False,
+                        type='bool',
+                        default=False
+                    ),
+                    local_egress_routing_policies=dict(
+                        required=False,
+                        type='list',
+                        elements='dict',
+                        options=dict(
+                            nexthop_address=dict(
+                                required=True,
+                                type='str'
+                            ),
+                            prefix_list_paths=dict(
+                                required=True,
+                                type='list',
+                                elements='str'
+                            ),
+                        )
+                    ),
+                    multicast=dict(
+                        required=False,
+                        type='bool'
+                    ),
+                    uplink_teaming_policy_name=dict(
+                        required=False,
+                        type='str'
+                    ),
+                )
+            ),
+            replication_mode=dict(
+                type='str',
+                default="MTEP",
+                choices=["MTEP", "SOURCE"]
+            ),
             subnets=dict(
                 required=False,
                 type='list',
+                elements='dict',
                 options=dict(
                     dhcp_ranges=dict(
                         required=False,
@@ -336,6 +592,27 @@ class NSXTSegment(NSXTBaseRealizableResource):
             nsx_resource_params["transport_zone_path"] = (
                 transport_zone_base_url + "/" + transport_zone_id)
 
+        if nsx_resource_params['advanced_config']:
+            if nsx_resource_params['advanced_config'][
+                    'address_pool_id']:
+                address_pool_id = nsx_resource_params['advanced_config'].pop(
+                    'address_pool_id')
+                nsx_resource_params['advanced_config'].pop(
+                    'address_pool_display_name')
+            else:
+                address_pool_id = self.get_id_from_display_name(
+                    IP_POOL_URL, nsx_resource_params['advanced_config'][
+                        'address_pool_display_name'], "Ip Pool",
+                    ignore_not_found_error=False)
+                nsx_resource_params['advanced_config'].pop(
+                    'address_pool_display_name')
+                nsx_resource_params['advanced_config'].pop(
+                    'address_pool_id')
+            if address_pool_id:
+                address_pool_paths = [IP_POOL_URL + "/" + address_pool_id]
+                nsx_resource_params['advanced_config'][
+                    'address_pool_paths'] = address_pool_paths
+
     def update_parent_info(self, parent_info):
         parent_info["segment_id"] = self.id
 
@@ -369,6 +646,12 @@ class NSXTSegment(NSXTBaseRealizableResource):
                         )
                     )
                 ),
+                admin_state=dict(
+                    required=False,
+                    type='str',
+                    default='UP',
+                    choices=['UP', 'DOWN']
+                ),
                 attachment=dict(
                     required=False,
                     type='dict',
@@ -400,6 +683,51 @@ class NSXTSegment(NSXTBaseRealizableResource):
                             choices=['PARENT', 'CHILD', 'INDEPENDENT']
                         )
                     )
+                ),
+                extra_configs=dict(
+                    required=False,
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        config_pair=dict(
+                            required=True,
+                            type='dict',
+                            options=dict(
+                                key=dict(
+                                    required=True,
+                                    type='str'
+                                ),
+                                value=dict(
+                                    required=True,
+                                    type='str'
+                                )
+                            )
+                        ),
+                    )
+                ),
+                ignored_address_bindings=dict(
+                    required=False,
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        ip_address=dict(
+                            required=False,
+                            type='str'
+                        ),
+                        mac_address=dict(
+                            required=False,
+                            type='str'
+                        ),
+                        vlan_id=dict(
+                            required=False,
+                            type='int'
+                        )
+                    )
+                ),
+                init_state=dict(
+                    type='str',
+                    default='UNBLOCKED_VLAN',
+                    choices=['UNBLOCKED_VLAN']
                 )
             )
             return segment_port_arg_spec

--- a/policy-ansible-for-nsxt/module_utils/nsxt_base_resource.py
+++ b/policy-ansible-for-nsxt/module_utils/nsxt_base_resource.py
@@ -361,13 +361,13 @@ class NSXTBaseRealizableResource(ABC):
                 params[display_name_identifier]):
             resource_display_name = params.pop(display_name_identifier)
             # Use display_name as ID if ID is not specified.
-            return (self._get_id_from_display_name(
+            return (self.get_id_from_display_name(
                 resource_base_url, resource_display_name, resource_type,
                 ignore_not_found_error) or resource_display_name)
 
-    def _get_id_from_display_name(self, resource_base_url,
-                                  resource_display_name,
-                                  resource_type, ignore_not_found_error=True):
+    def get_id_from_display_name(self, resource_base_url,
+                                 resource_display_name,
+                                 resource_type, ignore_not_found_error=True):
         try:
             # Get the id from the Manager
             (_, resp) = self._send_request_to_API(

--- a/policy-ansible-for-nsxt/unit_tests/test_nsxt_segment.yml
+++ b/policy-ansible-for-nsxt/unit_tests/test_nsxt_segment.yml
@@ -17,11 +17,28 @@
         state: present
         domain_name: dn1
         transport_zone_display_name: "1-transportzone-730"
+        replication_mode: "SOURCE"
+        address_bindings:
+          - ip_address: "10.1.2.11"
+        advanced_config:
+          address_pool_display_name: small-2-pool
+          connectivity: "OFF"
+          hybrid: True
+          local_egress: True
         subnets:
           - gateway_address: "40.1.1.1/16"
         segment_ports:
           - display_name: test-sp-1
             state: present
+            tags:
+              - scope: "scope-1"
+                tag: "tag-2"
+            extra_configs:
+              - config_pair:
+                  key: key
+                  value: value
+            ignored_address_bindings:
+              - ip_address: "10.1.2.122"
           - display_name: test-sp-2
             state: present
           - display_name: test-sp-3


### PR DESCRIPTION
These attributes can be configured using the API and hence must
be added to the Ansible Playbook configuration so that they
can be specified by the user.

Signed-off-by: Gautam Verma <vermag@vmware.com>
Signed-off-by: Gautam Verma <gautam94verma@gmail.com>