### PR TITLE
Add vmware_nsxt args to each module

### DIFF
--- a/policy-ansible-for-nsxt/library/nsxt_ip_block.py
+++ b/policy-ansible-for-nsxt/library/nsxt_ip_block.py
@@ -33,11 +33,59 @@ description:
     Required attributes include id and display_name.
 version_added: "2.8"
 author: Gautam Verma
-extends_documentation_fragment: vmware_nsxt
 options:
+    hostname:
+        description: Deployed NSX manager hostname.
+        required: true
+        type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+    display_name:
+        description:
+            - Display name.
+            - If resource ID is not specified, display_name will be used as ID.
+        required: false
+        type: str
+    state:
+        choices:
+        - present
+        - absent
+        description: "State can be either 'present' or 'absent'.
+                    'present' is used to create or update resource.
+                    'absent' is used to delete resource."
+        required: true
+    validate_certs:
+        description: Enable server certificate verification.
+        type: bool
+        default: False
+    tags:
+        description: Opaque identifiers meaningful to the API user.
+        type: dict
+        suboptions:
+            scope:
+                description: Tag scope.
+                required: true
+                type: str
+            tag:
+                description: Tag value.
+                required: true
+                type: str
+    do_wait_till_create:
+        type: bool
+        default: false
+        description:
+            - Can be used to wait for the realization of subresource before the
+              request to create the next resource is sent to the Manager.
+            - Can be specified for each subresource.
     id:
         description: The id of the Policy IP Block.
-        required: true
+        required: false
         type: str
     description:
         description: IP Block description.

--- a/policy-ansible-for-nsxt/library/nsxt_ip_pool.py
+++ b/policy-ansible-for-nsxt/library/nsxt_ip_pool.py
@@ -33,14 +33,81 @@ description:
     Required attributes include id and display_name.
 version_added: "2.8"
 author: Gautam Verma
-extends_documentation_fragment: vmware_nsxt
 options:
-    id:
-        description: The id of the Policy IP Pool.
+    hostname:
+        description: Deployed NSX manager hostname.
         required: true
         type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+    display_name:
+        description:
+            - Display name.
+            - If resource ID is not specified, display_name will be used as ID.
+        required: false
+        type: str
+    state:
+        choices:
+        - present
+        - absent
+        description: "State can be either 'present' or 'absent'.
+                    'present' is used to create or update resource.
+                    'absent' is used to delete resource."
+        required: true
+    validate_certs:
+        description: Enable server certificate verification.
+        type: bool
+        default: False
+    tags:
+        description: Opaque identifiers meaningful to the API user.
+        type: dict
+        suboptions:
+            scope:
+                description: Tag scope.
+                required: true
+                type: str
+            tag:
+                description: Tag value.
+                required: true
+                type: str
+    create_or_update_subresource_first:
+        type: bool
+        default: false
+        description:
+            - Can be used to create subresources first.
+            - Can be specified for each subresource.
+    delete_subresource_first:
+        type: bool
+        default: true
+        description:
+            - Can be used to delete subresources first.
+            - Can be specified for each subresource.
+    achieve_subresource_state_if_del_parent:
+        type: bool
+        default: false
+        description:
+            - Can be used to achieve the state of subresources even if
+              the parent(base) resource's state is absent.
+            - Can be specified for each subresource.
+    do_wait_till_create:
+        type: bool
+        default: false
+        description:
+            - Can be used to wait for the realization of subresource before the
+              request to create the next resource is sent to the Manager.
+            - Can be specified for each subresource.
+    id:
+        description: The id of the Policy IP Pool.
+        required: false
+        type: str
     description:
-        description: IP Pool description.
+        description: Resource description.
         type: str
     pool_block_subnets:
         type: list
@@ -48,16 +115,6 @@ options:
         description: Specify the IP Pool Block Subnets that need to be created,
                      updated, or deleted as a list of dict in this section
         suboptions:
-            ip_block_id:
-                description: The ID of the IpAddressBlock from which the subnet
-                             is to be created
-                type: str
-            ip_block_display_name:
-                description: Same as ip_block_id. Either one must be specified.
-                             If both are specified, ip_block_id takes
-                             precedence.
-                required: false
-                type: str
             auto_assign_gateway:
                 description:
                     - Indicate whether default gateway is to be reserved from
@@ -66,6 +123,36 @@ options:
                       range will be reserved for gateway.
                 type: bool
                 default: true
+            description:
+                description: Resource description.
+                type: str
+            display_name:
+                description:
+                    - Display name.
+                    - If resource ID is not specified, display_name will be
+                      used as ID.
+                required: false
+                type: str
+            do_wait_till_create:
+                type: bool
+                default: false
+                description: Can be used to wait for the realization of
+                             subresource before the request to create the next
+                             resource is sent to the Manager
+            id:
+                description: The id of the Policy IP Pool Block Subnet.
+                required: false
+                type: str
+            ip_block_display_name:
+                description: Same as ip_block_id. Either one must be specified.
+                             If both are specified, ip_block_id takes
+                             precedence.
+                required: false
+                type: str
+            ip_block_id:
+                description: The ID of the IpAddressBlock from which the subnet
+                             is to be created
+                type: str
             size:
                 description:
                     - Represents the size or number of IP addresses in the
@@ -74,6 +161,26 @@ options:
                       must be specified during creation but cannot be changed
                       later.
                 type: int
+            state:
+                choices:
+                - present
+                - absent
+                description: "State can be either 'present' or 'absent'.
+                            'present' is used to create or update resource.
+                            'absent' is used to delete resource."
+                required: true
+            tags:
+                description: Opaque identifiers meaningful to the API user.
+                type: dict
+                suboptions:
+                    scope:
+                        description: Tag scope.
+                        required: true
+                        type: str
+                    tag:
+                        description: Tag value.
+                        required: true
+                        type: str
     pool_static_subnets:
         type: list
         element: dict
@@ -99,6 +206,16 @@ options:
                              and prefix length
                 type: str
                 required: true
+            description:
+                description: Resource description.
+                type: str
+            display_name:
+                description:
+                    - Display name.
+                    - If resource ID is not specified, display_name will be
+                      used as ID.
+                required: false
+                type: str
             dns_nameservers:
                 description: The collection of upto 3 DNS servers
                              for the subnet.
@@ -107,10 +224,39 @@ options:
             dns_suffix:
                 description: The DNS suffix for the DNS server.
                 type: str
+            do_wait_till_create:
+                type: bool
+                default: false
+                description: Can be used to wait for the realization of
+                             subresource before the request to create the next
+                             resource is sent to the Manager
             gateway_ip:
                 description: The default gateway address on a
                              layer-3 router.
                 type: str
+            id:
+                description: The id of the Policy IP Pool Block Subnet.
+                required: false
+                type: str
+            state:
+                choices:
+                - present
+                - absent
+                description: "State can be either 'present' or 'absent'.
+                            'present' is used to create or update resource.
+                            'absent' is used to delete resource."
+            tags:
+                description: Opaque identifiers meaningful to the API user.
+                type: dict
+                suboptions:
+                    scope:
+                        description: Tag scope.
+                        required: true
+                        type: str
+                    tag:
+                        description: Tag value.
+                        required: true
+                        type: str
 '''
 
 EXAMPLES = '''

--- a/policy-ansible-for-nsxt/library/nsxt_policy_group.py
+++ b/policy-ansible-for-nsxt/library/nsxt_policy_group.py
@@ -33,11 +33,59 @@ description:
     Required attributes include id and display_name.
 version_added: "2.8"
 author: Gautam Verma
-extends_documentation_fragment: vmware_nsxt
 options:
+    hostname:
+        description: Deployed NSX manager hostname.
+        required: true
+        type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+    display_name:
+        description:
+            - Display name.
+            - If resource ID is not specified, display_name will be used as ID.
+        required: false
+        type: str
+    state:
+        choices:
+        - present
+        - absent
+        description: "State can be either 'present' or 'absent'.
+                    'present' is used to create or update resource.
+                    'absent' is used to delete resource."
+        required: true
+    validate_certs:
+        description: Enable server certificate verification.
+        type: bool
+        default: False
+    tags:
+        description: Opaque identifiers meaningful to the API user.
+        type: dict
+        suboptions:
+            scope:
+                description: Tag scope.
+                required: true
+                type: str
+            tag:
+                description: Tag value.
+                required: true
+                type: str
+    do_wait_till_create:
+        type: bool
+        default: false
+        description:
+            - Can be used to wait for the realization of subresource before the
+              request to create the next resource is sent to the Manager.
+            - Can be specified for each subresource.
     id:
         description: The id of the Policy Policy Group.
-        required: true
+        required: false
         type: str
     description:
         description: Policy Group description.

--- a/policy-ansible-for-nsxt/library/nsxt_security_policy.py
+++ b/policy-ansible-for-nsxt/library/nsxt_security_policy.py
@@ -33,11 +33,59 @@ description:
     Required attributes include id and display_name.
 version_added: "2.8"
 author: Gautam Verma
-extends_documentation_fragment: vmware_nsxt
 options:
+    hostname:
+        description: Deployed NSX manager hostname.
+        required: true
+        type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+    display_name:
+        description:
+            - Display name.
+            - If resource ID is not specified, display_name will be used as ID.
+        required: false
+        type: str
+    state:
+        choices:
+        - present
+        - absent
+        description: "State can be either 'present' or 'absent'.
+                    'present' is used to create or update resource.
+                    'absent' is used to delete resource."
+        required: true
+    validate_certs:
+        description: Enable server certificate verification.
+        type: bool
+        default: False
+    tags:
+        description: Opaque identifiers meaningful to the API user.
+        type: dict
+        suboptions:
+            scope:
+                description: Tag scope.
+                required: true
+                type: str
+            tag:
+                description: Tag value.
+                required: true
+                type: str
+    do_wait_till_create:
+        type: bool
+        default: false
+        description:
+            - Can be used to wait for the realization of subresource before the
+              request to create the next resource is sent to the Manager.
+            - Can be specified for each subresource.
     id:
         description: The id of the Policy Security Policy.
-        required: true
+        required: false
         type: str
     description:
         description: Security Policy description.

--- a/policy-ansible-for-nsxt/library/nsxt_segment.py
+++ b/policy-ansible-for-nsxt/library/nsxt_segment.py
@@ -34,11 +34,78 @@ description:
     If the specified TransportZone is of VLAN type, a vlan_id is also required.
 version_added: "2.8"
 author: Gautam Verma
-extends_documentation_fragment: vmware_nsxt
 options:
+    hostname:
+        description: Deployed NSX manager hostname.
+        required: true
+        type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+    display_name:
+        description:
+            - Display name.
+            - If resource ID is not specified, display_name will be used as ID.
+        required: false
+        type: str
+    state:
+        choices:
+        - present
+        - absent
+        description: "State can be either 'present' or 'absent'.
+                    'present' is used to create or update resource.
+                    'absent' is used to delete resource."
+        required: true
+    validate_certs:
+        description: Enable server certificate verification.
+        type: bool
+        default: False
+    tags:
+        description: Opaque identifiers meaningful to the API user.
+        type: dict
+        suboptions:
+            scope:
+                description: Tag scope.
+                required: true
+                type: str
+            tag:
+                description: Tag value.
+                required: true
+                type: str
+    create_or_update_subresource_first:
+        type: bool
+        default: false
+        description:
+            - Can be used to create subresources first.
+            - Can be specified for each subresource.
+    delete_subresource_first:
+        type: bool
+        default: true
+        description:
+            - Can be used to delete subresources first.
+            - Can be specified for each subresource.
+    achieve_subresource_state_if_del_parent:
+        type: bool
+        default: false
+        description:
+            - Can be used to achieve the state of subresources even if
+              the parent(base) resource's state is absent.
+            - Can be specified for each subresource.
+    do_wait_till_create:
+        type: bool
+        default: false
+        description:
+            - Can be used to wait for the realization of subresource before the
+              request to create the next resource is sent to the Manager.
+            - Can be specified for each subresource.
     id:
         description: The id of the Policy Segment.
-        required: true
+        required: false
         type: str
     description:
         description: Segment description.
@@ -216,43 +283,6 @@ options:
               section
         element: dict
         suboptions:
-            id:
-                description: The id of the Policy Segment Port.
-                required: false
-                type: str
-            display_name:
-                description:
-                    - Segment Port display name.
-                    - Either this or id must be specified. If both are
-                      specified, id takes precedence.
-                required: false
-                type: str
-            description:
-                description:
-                    - Segment description.
-                type: str
-            tags:
-                description: Opaque identifiers meaningful to the API user.
-                type: dict
-            suboptions:
-                scope:
-                    description: Tag scope.
-                    required: true
-                    type: str
-                tag:
-                    description: Tag value.
-                    required: true
-                    type: str
-            state:
-                choices:
-                    - present
-                    - absent
-                description:
-                    - State can be either 'present' or 'absent'. 'present' is
-                      used to create or update resource. 'absent' is used to
-                      delete resource
-                    - Required if I(id != null)
-                required: true
             address_bindings:
                 description: Static address binding used for the port.
                 type: dict
@@ -306,6 +336,23 @@ options:
                             - PARENT
                             - CHILD
                             - INDEPENDENT
+            display_name:
+                description:
+                    - Segment Port display name.
+                    - Either this or id must be specified. If both are
+                      specified, id takes precedence.
+                required: false
+                type: str
+            description:
+                description:
+                    - Segment description.
+                type: str
+            do_wait_till_create:
+                type: bool
+                default: false
+                description: Can be used to wait for the realization of
+                             subresource before the request to create the next
+                             resource is sent to the Manager
             extra_configs:
                 description:
                     - Extra configs on segment port
@@ -330,6 +377,10 @@ options:
                                 description: Value
                                 type: str
                                 required: true
+            id:
+                description: The id of the Policy Segment Port.
+                required: false
+                type: str
             ignored_address_bindings:
                 description:
                     - Address bindings to be ignored by IP Discovery module
@@ -364,6 +415,28 @@ options:
                 choices:
                     - UNBLOCKED_VLAN
                 default: UNBLOCKED_VLAN
+            state:
+                choices:
+                    - present
+                    - absent
+                description:
+                    - State can be either 'present' or 'absent'. 'present' is
+                      used to create or update resource. 'absent' is used to
+                      delete resource
+                    - Required if I(id != null)
+                required: true
+            tags:
+                description: Opaque identifiers meaningful to the API user.
+                type: dict
+                suboptions:
+                    scope:
+                        description: Tag scope.
+                        required: true
+                        type: str
+                    tag:
+                        description: Tag value.
+                        required: true
+                        type: str
 '''
 
 EXAMPLES = '''

--- a/policy-ansible-for-nsxt/library/nsxt_tier0.py
+++ b/policy-ansible-for-nsxt/library/nsxt_tier0.py
@@ -34,11 +34,78 @@ description: Creates/Updates/Deletes a Tier-0 resource using the Policy API.
              respectively.
 version_added: '2.8'
 author: 'Gautam Verma'
-extends_documentation_fragment: vmware_nsxt
 options:
+    hostname:
+        description: Deployed NSX manager hostname.
+        required: true
+        type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+    display_name:
+        description:
+            - Display name.
+            - If resource ID is not specified, display_name will be used as ID.
+        required: false
+        type: str
+    state:
+        choices:
+        - present
+        - absent
+        description: "State can be either 'present' or 'absent'.
+                    'present' is used to create or update resource.
+                    'absent' is used to delete resource."
+        required: true
+    validate_certs:
+        description: Enable server certificate verification.
+        type: bool
+        default: False
+    tags:
+        description: Opaque identifiers meaningful to the API user.
+        type: dict
+        suboptions:
+            scope:
+                description: Tag scope.
+                required: true
+                type: str
+            tag:
+                description: Tag value.
+                required: true
+                type: str
+    create_or_update_subresource_first:
+        type: bool
+        default: false
+        description:
+            - Can be used to create subresources first.
+            - Can be specified for each subresource.
+    delete_subresource_first:
+        type: bool
+        default: true
+        description:
+            - Can be used to delete subresources first.
+            - Can be specified for each subresource.
+    achieve_subresource_state_if_del_parent:
+        type: bool
+        default: false
+        description:
+            - Can be used to achieve the state of subresources even if
+              the parent(base) resource's state is absent.
+            - Can be specified for each subresource.
+    do_wait_till_create:
+        type: bool
+        default: false
+        description:
+            - Can be used to wait for the realization of subresource before the
+              request to create the next resource is sent to the Manager.
+            - Can be specified for each subresource.
     id:
         description: Tier-0 ID
-        required: true
+        required: false
         type: str
     description:
         description: Tier-0 description
@@ -49,7 +116,6 @@ options:
                      whitelisting rule.
         type: str
         default: false
-        type: bool
     ha_mode:
         description: High-availability Mode for Tier-0
         choices:
@@ -282,6 +348,20 @@ options:
                         description: Tag value.
                         required: true
                         type: str
+            achieve_subresource_state_if_del_parent:
+                type: bool
+                default: false
+                description:
+                    - Can be used to achieve the state of subresources even if
+                      the parent(base) resource's state is absent.
+                    - Can be specified for each subresource.
+            do_wait_till_create:
+                type: bool
+                default: false
+                description:
+                    - Can be used to wait for the realization of subresource
+                      before the request to create the next resource is sent to
+                      the Manager
     locale_services:
         type: list
         element: dict
@@ -324,6 +404,33 @@ options:
                         description: Tag value.
                         required: true
                         type: str
+            create_or_update_subresource_first:
+                type: bool
+                default: false
+                description:
+                    - Can be used to create subresources first.
+                    - Can be specified for each subresource.
+            delete_subresource_first:
+                type: bool
+                default: true
+                description:
+                    - Can be used to delete subresources first.
+                    - Can be specified for each subresource.
+            achieve_subresource_state_if_del_parent:
+                type: bool
+                default: false
+                description:
+                    - Can be used to achieve the state of subresources even if
+                      the parent(base) resource's state is absent.
+                    - Can be specified for each subresource.
+            do_wait_till_create:
+                type: bool
+                default: false
+                description:
+                    - Can be used to wait for the realization of subresource
+                      before the request to create the next resource is sent to
+                      the Manager.
+                    - Can be specified for each subresource.
             edge_cluster_info:
                 description: Used to create path to edge cluster. Auto-assigned
                             if associated enforcement-point has only one edge
@@ -768,6 +875,34 @@ options:
                                 description: Tag value.
                                 required: true
                                 type: str
+                    create_or_update_subresource_first:
+                        type: bool
+                        default: false
+                        description:
+                            - Can be used to create subresources first.
+                            - Can be specified for each subresource.
+                    delete_subresource_first:
+                        type: bool
+                        default: true
+                        description:
+                            - Can be used to delete subresources first.
+                            - Can be specified for each subresource.
+                    achieve_subresource_state_if_del_parent:
+                        type: bool
+                        default: false
+                        description:
+                            - Can be used to achieve the state of subresources
+                              even if the parent(base) resource's state is
+                              absent.
+                            - Can be specified for each subresource.
+                    do_wait_till_create:
+                        type: bool
+                        default: false
+                        description:
+                            - Can be used to wait for the realization of
+                              subresource before the request to create the next
+                              resource is sent to the Manager.
+                            - Can be specified for each subresource.
                     segment_id:
                         description: Specify Segment to which this interface is
                                      connected to. Required if id is specified.

--- a/policy-ansible-for-nsxt/library/nsxt_tier1.py
+++ b/policy-ansible-for-nsxt/library/nsxt_tier1.py
@@ -34,11 +34,78 @@ description: Creates/Updates/Deletes a Tier-1 resource using the Policy API.
              respectively.
 version_added: '2.8'
 author: 'Gautam Verma'
-extends_documentation_fragment: vmware_nsxt
 options:
+    hostname:
+        description: Deployed NSX manager hostname.
+        required: true
+        type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+    display_name:
+        description:
+            - Display name.
+            - If resource ID is not specified, display_name will be used as ID.
+        required: false
+        type: str
+    state:
+        choices:
+        - present
+        - absent
+        description: "State can be either 'present' or 'absent'.
+                    'present' is used to create or update resource.
+                    'absent' is used to delete resource."
+        required: true
+    validate_certs:
+        description: Enable server certificate verification.
+        type: bool
+        default: False
+    tags:
+        description: Opaque identifiers meaningful to the API user.
+        type: dict
+        suboptions:
+            scope:
+                description: Tag scope.
+                required: true
+                type: str
+            tag:
+                description: Tag value.
+                required: true
+                type: str
+    create_or_update_subresource_first:
+        type: bool
+        default: false
+        description:
+            - Can be used to create subresources first.
+            - Can be specified for each subresource.
+    delete_subresource_first:
+        type: bool
+        default: true
+        description:
+            - Can be used to delete subresources first.
+            - Can be specified for each subresource.
+    achieve_subresource_state_if_del_parent:
+        type: bool
+        default: false
+        description:
+            - Can be used to achieve the state of subresources even if
+              the parent(base) resource's state is absent.
+            - Can be specified for each subresource.
+    do_wait_till_create:
+        type: bool
+        default: false
+        description:
+            - Can be used to wait for the realization of subresource before the
+              request to create the next resource is sent to the Manager.
+            - Can be specified for each subresource.
     id:
         description: Tier-1 ID
-        required: true
+        required: false
         type: str
     description:
         description: Tier-1 description
@@ -49,7 +116,6 @@ options:
                      whitelisting rule.
         type: str
         default: false
-        type: bool
     disable_firewall:
         description: Disable or enable gateway fiewall.
         default: False
@@ -233,6 +299,20 @@ options:
                         description: Tag value.
                         required: true
                         type: str
+            achieve_subresource_state_if_del_parent:
+                type: bool
+                default: false
+                description:
+                    - Can be used to achieve the state of subresources even if
+                      the parent(base) resource's state is absent.
+                    - Can be specified for each subresource.
+            do_wait_till_create:
+                type: bool
+                default: false
+                description:
+                    - Can be used to wait for the realization of subresource
+                      before the request to create the next resource is sent to
+                      the Manager
     locale_services:
         type: list
         element: dict
@@ -273,6 +353,20 @@ options:
                         description: Tag value.
                         required: true
                         type: str
+            achieve_subresource_state_if_del_parent:
+                type: bool
+                default: false
+                description:
+                    - Can be used to achieve the state of subresources even if
+                      the parent(base) resource's state is absent.
+                    - Can be specified for each subresource.
+            do_wait_till_create:
+                type: bool
+                default: false
+                description:
+                    - Can be used to wait for the realization of subresource
+                      before the request to create the next resource is sent to
+                      the Manager
             edge_cluster_info:
                 description: Used to create path to edge cluster. Auto-assigned
                              if associated enforcement-point has only one edge
@@ -444,6 +538,21 @@ options:
                                 description: Tag value.
                                 required: true
                                 type: str
+                    achieve_subresource_state_if_del_parent:
+                        type: bool
+                        default: false
+                        description:
+                            - Can be used to achieve the state of subresources
+                              even if the parent(base) resource's state is
+                              absent.
+                            - Can be specified for each subresource.
+                    do_wait_till_create:
+                        type: bool
+                        default: false
+                        description:
+                            - Can be used to wait for the realization of
+                              subresource before the request to create the next
+                              resource is sent to the Manager
                     ipv6_ndra_profile_id:
                         description:
                             - Configrue IPv6 NDRA profile. Only one NDRA

--- a/policy-ansible-for-nsxt/plugins/doc_fragments/vmware_nsxt.py
+++ b/policy-ansible-for-nsxt/plugins/doc_fragments/vmware_nsxt.py
@@ -37,7 +37,7 @@ options:
         description:
             - Display name.
             - If resource ID is not specified, display_name will be used as ID.
-        required: true
+        required: false
         type: str
     state:
         choices:
@@ -71,7 +71,7 @@ options:
             - Can be specified for each subresource.
     delete_subresource_first:
         type: bool
-        default: false
+        default: true
         description:
             - Can be used to delete subresources first.
             - Can be specified for each subresource.


### PR DESCRIPTION
doc_fragments support is only available in collections. So, when we
move to Ansible collections, we will use vmware_nsxt to create
the Ansible module documentation. Until then, we add all the fields
in the DOCUMENTATION to each module.

Signed-off-by: Gautam Verma <vermag@vmware.com>
Signed-off-by: Gautam Verma <gautam94verma@gmail.com>