### PR TITLE
Update nsxt_transport_zones

### DIFF
--- a/library/nsxt_transport_zones.py
+++ b/library/nsxt_transport_zones.py
@@ -160,15 +160,21 @@ def check_for_update(module, manager_url, mgr_username, mgr_password, validate_c
         return False
     if not existing_transport_zone.__contains__('is_default') and transport_zone_params.__contains__('is_default'):
         return True
+    if existing_transport_zone.__contains__('is_default') and not transport_zone_params.__contains__('is_default'):
+        return True
     if existing_transport_zone.__contains__('is_default') and transport_zone_params.__contains__('is_default') and \
         existing_transport_zone['is_default'] != transport_zone_params['is_default']:
         return True
     if not existing_transport_zone.__contains__('description') and transport_zone_params.__contains__('description'):
         return True
+    if existing_transport_zone.__contains__('description') and not transport_zone_params.__contains__('description'):
+        return True
     if existing_transport_zone.__contains__('description') and transport_zone_params.__contains__('description') and \
         existing_transport_zone['description'] != transport_zone_params['description']:
         return True
     if not existing_transport_zone.__contains__('uplink_teaming_policy_names') and transport_zone_params.__contains__('uplink_teaming_policy_names'):
+        return True
+    if existing_transport_zone.__contains__('uplink_teaming_policy_names') and not transport_zone_params.__contains__('uplink_teaming_policy_names'):
         return True
     if existing_transport_zone.__contains__('uplink_teaming_policy_names') and transport_zone_params.__contains__('uplink_teaming_policy_names') and \
         existing_transport_zone['uplink_teaming_policy_names'] != transport_zone_params['uplink_teaming_policy_names']:


### PR DESCRIPTION
Updating Transport Zones was not working when  deleting
uplink_teaming_policy_names. This issue is solved.
This solves bugzilla #2516098.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>