### PR TITLE
Adding support for node_id, node_name

### DIFF
--- a/library/nsxt_principal_identities.py
+++ b/library/nsxt_principal_identities.py
@@ -261,7 +261,7 @@ def main():
         module.exit_json(changed=True, result=resp, message="Principal identity updated.")
     # add the principal identity
     if principal_id_with_display_name:
-      module.fail_json(msg="Principal id with display name \'%s\' already exists." % display_name)  
+      module.exit_json(changed=False, msg="Principal id with display name \'%s\' already exists." % display_name) 
     request_data = json.dumps(principal_id_params)
     try:
         (rc, resp) = request(manager_url+ '/trust-management/principal-identities/with-certificate', data=request_data, headers=headers, method='POST',


### PR DESCRIPTION
Support for node_id and node_name are added while
deleting the autodeployed manager node. The priority of deletion
is node_id followed by node_name.
Principal id module
Principal id if already exists then made to exit gracefully.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>