### PR TITLE
Upgrade pre check break

### DIFF
--- a/library/nsxt_upgrade_prechecks.py
+++ b/library/nsxt_upgrade_prechecks.py
@@ -152,14 +152,15 @@ def main():
     time.sleep(5)
     changed = False
     try:
-      (rc, resp) = request(manager_url+ '/upgrade/pre-upgrade-checks?format=csv', 
+      (rc, resp) = request(manager_url+ '/upgrade/pre-upgrade-checks/failures',
                            url_username=mgr_username, url_password=mgr_password, 
                            validate_certs=validate_certs)
     except Exception as err:
       module.fail_json(msg='Pre upgrade checks were executed successfully but error'
                   ' occured while retrieving the results. Error [%s]' % (to_native(err)))
-    module.exit_json(changed=changed, message='Pre upgrade checks are performed successfully:\n'
-                     '----------------------------\n' + str(resp))
+    module.exit_json(changed=changed, message='Pre upgrade checks are performed successfully:'
+                     ' Failures are listed. To get full report run upgrade groups '
+                     'facts module.' + str(resp))
   elif state == 'absent':
     # Aborts pre upgrade checks
     try:


### PR DESCRIPTION
Upgrade pre check was failing to retrieve data from an API,
as API was responding in csv format. This issue is not
happening in python 2 but occurring in Python3 due to
type changes in python3 response.
Given that there were previous suggestions about not showing
csv format on the ansible output as it is confusing. Showing
the upgrade results from upgrade/pre-upgrade-checks/failures
rather than upgrade/pre-upgrade-checks?format=csv
This works from both versions of python 2 and 3.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>