### PR TITLE
Edge Cluster Unloadable

### DIFF
--- a/library/nsxt_edge_clusters.py
+++ b/library/nsxt_edge_clusters.py
@@ -182,6 +182,7 @@ def check_for_update(module, manager_url, mgr_username, mgr_password, validate_c
         return True
     if existing_edge_cluster.__contains__('description') and edge_cluster_with_id.__contains__('description') and \
         existing_edge_cluster['description'] != edge_cluster_with_id['description']:
+        return True
     if existing_edge_cluster.__contains__('members') and not edge_cluster_with_id.__contains__('members'):
         return True
     if not existing_edge_cluster.__contains__('members') and edge_cluster_with_id.__contains__('members'):


### PR DESCRIPTION
Issue occurred while resolving conflict on edge cluster module.
The return value was not passed correctly, hence causing the
break where python file was failing to compile. the issue is
fixed in this CL.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>