### PR TITLE
Adding node deployment info revision

### DIFF
--- a/library/nsxt_transport_nodes.py
+++ b/library/nsxt_transport_nodes.py
@@ -868,10 +868,12 @@ def main():
   manager_url = 'https://{}/api/v1'.format(mgr_hostname)
 
   transport_node_dict = get_tn_from_display_name (module, manager_url, mgr_username, mgr_password, validate_certs, display_name)
-  transport_node_id, revision = None, None
+  transport_node_id, revision, node_deployment_revision = None, None, None
   if transport_node_dict:
     transport_node_id = transport_node_dict['id']
     revision = transport_node_dict['_revision']
+    if transport_node_dict.__contains__('node_deployment_info'):
+      node_deployment_revision = transport_node_dict['node_deployment_info']['_revision']
 
   if state == 'present':
     if transport_node_params['node_deployment_info']['resource_type'] == 'EdgeNode':
@@ -915,8 +917,11 @@ def main():
 
       body['_revision'] = revision # update current revision
       # node deployment revision is also important - node id also has a revision
-      if body.__contains__('node_deployment_info'):
-          body['node_deployment_info']['_revision'] = revision
+      if body.__contains__('node_deployment_info') and node_deployment_revision is not None:
+          body['node_deployment_info']['_revision'] = node_deployment_revision
+      else:
+          module.fail_json(msg="Either node deployment info is not provided or "
+            "node deployement revision couldn't be retrieved.")
       #update node id with tn id - as result of FN TN unification
       body['node_id'] = transport_node_id
 

--- a/library/nsxt_transport_nodes.py
+++ b/library/nsxt_transport_nodes.py
@@ -920,7 +920,7 @@ def main():
       if body.__contains__('node_deployment_info') and node_deployment_revision is not None:
           body['node_deployment_info']['_revision'] = node_deployment_revision
       else:
-          module.fail_json(msg="Either node deployment info is not provided or "
+          module.fail_json(msg="Failed to update Transport Node. Either node deployment info is not provided or "
             "node deployement revision couldn't be retrieved.")
       #update node id with tn id - as result of FN TN unification
       body['node_id'] = transport_node_id


### PR DESCRIPTION
Node deplyment info revision is a mandatory field while updating
a transport node. Previously the node deployment info being passed
was same as the resource revision as in most of the cases they
are same. Now node deployment info revision is passed after
retrieving the current revision.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>