### PR TITLE
Add support for .p12 certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Note: usr_cert tells OpenSSL to generate a client certificate. This must be defi
 All the Policy API based Ansible Modules provide the following authentication mechanisms:
 
 ##### Basic Authentication
-By specifying the following fields in the playbook:
+This is the same as in MP API. It can be used by specifying the following fields in the playbook:
 1. **username**: The username to authenticate with the NSX manager
 2. **password**: The password to authenticate with the NSX manager
 
@@ -179,8 +179,14 @@ For example:
 ```
 
 ##### Prinicipal Identity
+There are 2 ways to consume the Principal Identity certificates.
+
+###### Using Environment variable
+This is same as explained in the previous section: **Certificate based authentication**
+
+###### Specying in the playbook
 By specifying the following fields in the playbook:
-1. **nsx_cert_path**: Path to the certificate created for the Principal Identity using which the CRUD operations should be performed
+1. **nsx_cert_path**: Path to the certificate created for the Principal Identity using which the CRUD operations should be performed. If the certificate is a .p12 file, only this attribute is required. Otherwise, *nsx_key_path* is also required.
 2. **nsx_key_path**: Path to the certificate key created for the Principal Identity using which the CRUD operations should be performed
 
 For example:

--- a/module_utils/policy_communicator.py
+++ b/module_utils/policy_communicator.py
@@ -23,6 +23,7 @@ import hashlib
 
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.error import HTTPError
+from ansible.module_utils.vmware_nsxt import get_certificate_file_path
 
 
 class PolicyCommunicator:
@@ -43,12 +44,17 @@ class PolicyCommunicator:
                 raise InvalidInstanceRequest("mgr_password ")
             key = tuple([mgr_hostname, mgr_username, mgr_password])
         elif nsx_cert_path is not None:
-            if nsx_key_path is None:
+            if not nsx_cert_path.endswith('.p12') and nsx_key_path is None:
                 raise InvalidInstanceRequest("nsx_key_path")
             key = tuple([mgr_hostname, nsx_cert_path, nsx_key_path])
+        elif get_certificate_file_path('NSX_MANAGER_CERT_PATH') is not None:
+            nsx_cert_path = get_certificate_file_path('NSX_MANAGER_CERT_PATH')
+            key = tuple([mgr_hostname, nsx_cert_path])
         else:
             raise InvalidInstanceRequest("(mgr_username, mgr_password) or"
-                                         "(nsx_cert_path, nsx_key_path)")
+                                         "(nsx_cert_path, nsx_key_path), or "
+                                         "environment variable "
+                                         "'NSX_MANAGER_CERT_PATH'")
         if key not in PolicyCommunicator.__instances:
             PolicyCommunicator(key, mgr_hostname, mgr_username, mgr_password,
                                nsx_cert_path, nsx_key_path, request_headers,


### PR DESCRIPTION
.p12 certificates are used in MP based Ansible Modules. Before we
can merge Policy into MP, Policy modules must support .p12
certificates as well.

Signed-off-by: Gautam Verma <vermag@vmware.com>