### PR TITLE
IP Pools and blocks issues

### DIFF
--- a/library/nsxt_ip_blocks.py
+++ b/library/nsxt_ip_blocks.py
@@ -66,6 +66,7 @@ EXAMPLES = '''
     display_name: "IPBlock-Tenant-1",
     description: "IPBlock-Tenant-1 Description",
     cidr: "192.168.0.0/16"
+    state: present
 '''
 
 RETURN = '''# '''

--- a/library/nsxt_ip_blocks_facts.py
+++ b/library/nsxt_ip_blocks_facts.py
@@ -10,16 +10,15 @@
 # WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request
 from ansible.module_utils.urls import open_url, fetch_url
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six.moves.urllib.error import HTTPError
-
-
-from __future__ import absolute_import, division, print_function
-__metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',

--- a/library/nsxt_ip_pools.py
+++ b/library/nsxt_ip_pools.py
@@ -60,6 +60,14 @@ options:
         description: 'Opaque identifiers meaningful to the API user'
         required: false
         type: str
+    description:
+        description: 'description of the resource'
+        required: false
+        type: str
+    ip_release_delay:
+        description: 'IP address release delay'
+        required: false
+        type: int
 
     
 '''
@@ -132,7 +140,9 @@ def main():
   argument_spec = vmware_argument_spec()
   argument_spec.update(display_name=dict(required=True, type='str'),
                         subnets=dict(required=False, type='list'),
-                        tags=dict(required=False, type='str'),
+                        tags=dict(required=False, type='list'),
+                        description=(required=False, type='str'),
+                        ip_release_delay=(required=False, type='int'),
                         state=dict(required=True, choices=['present', 'absent']))
 
   module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)

--- a/library/nsxt_logical_switches_facts.py
+++ b/library/nsxt_logical_switches_facts.py
@@ -74,7 +74,7 @@ def main():
 
   changed = False
   try:
-    (rc, resp) = request(manager_url+ '/logical-ports', headers=dict(Accept='application/json'),
+    (rc, resp) = request(manager_url+ '/logical-switches', headers=dict(Accept='application/json'),
                     url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
   except Exception as err:
     module.fail_json(msg='Error accessing list of logical ports. Error [%s]' % (to_native(err)))

--- a/library/nsxt_transport_nodes.py
+++ b/library/nsxt_transport_nodes.py
@@ -521,8 +521,6 @@ EXAMPLES = '''
           ip_pool_name: "IPPool-IPV4-1"
         transport_zone_endpoints:
         - transport_zone_name: "TZ1"
-    transport_zone_endpoints:
-    - transport_zone_name: "TZ1"
     node_deployment_info:
       resource_type: "HostNode"
       display_name: "Host_1"

--- a/test_ip_blocks.yml
+++ b/test_ip_blocks.yml
@@ -1,0 +1,15 @@
+- hosts: 127.0.0.1
+  connection: local
+  become: yes
+  vars_files:
+    - answerfile.yml
+  tasks:
+    - name: Create ip block
+      nsxt_ip_blocks:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "MyDisplayname"
+        cidr: "192.168.0.0/16"
+        state: present

--- a/test_ip_blocks_facts.yml
+++ b/test_ip_blocks_facts.yml
@@ -1,0 +1,12 @@
+- hosts: 127.0.0.1
+  connection: local
+  become: yes
+  vars_files:
+    - answerfile.yml
+  tasks:
+    - name: List IP address block
+      nsxt_ip_blocks_facts:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False


### PR DESCRIPTION
There were issues with IP pools.
1. Tags param was in format of str instead of list causing module
to fail.
2. Optional params description and ip_release_delay were added.

Corrected transport node example

Facts module of logical switch was calling incorrect API. Corrected.

Playbook files added for IP block modules.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>