### PR TITLE
Post upgrade checks not quitting

### DIFF
--- a/library/nsxt_upgrade_postchecks.py
+++ b/library/nsxt_upgrade_postchecks.py
@@ -95,7 +95,9 @@ def wait_for_post_upgrade_checks_to_execute(module, manager_url, endpoint, mgr_u
       results = resp['results']
       for result in results:
         if result['post_upgrade_status']['status'] != 'COMPLETED' and \
-           result['type'] == component_type.upper():
+           result['type'] == component_type.upper() and \
+           result['upgrade_unit_count'] > 0 and \
+           result['status'] != 'NOT_STARTED':
           flag = False
       if flag:
         return None


### PR DESCRIPTION
post upgrade checks module was not auto quitting. This is because
we were not checking if the component is upgraded or not and also
we were not checking if upgrade unit exists in the upgrade
group.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>