### PR TITLE
nsxt_logical_port and nsxt_logical_switches correction

### DIFF
--- a/library/nsxt_logical_ports.py
+++ b/library/nsxt_logical_ports.py
@@ -156,7 +156,7 @@ options:
                      'absent' is used to delete resource."
         required: true
     switching_profiles:
-        description: List of Switching Profiles name
+        description: List of Switching Profiles name and type
         required: false
         type: list 
 '''
@@ -245,7 +245,7 @@ def update_params_with_id (module, manager_url, mgr_username, mgr_password, vali
         for host_switch_profile in host_switch_profiles:
             profile_obj = {}
             profile_obj['value'] = get_id_from_display_name (module, manager_url, mgr_username, mgr_password, validate_certs,
-                                                    "/host-switch-profiles", host_switch_profile['name'])
+                                                    "/switching-profiles", host_switch_profile['name'])
             profile_obj['key'] = host_switch_profile['type']
             host_switch_profile_ids.append(profile_obj)
     logical_port_params['switching_profile_ids'] = host_switch_profile_ids

--- a/library/nsxt_logical_switches.py
+++ b/library/nsxt_logical_switches.py
@@ -124,7 +124,7 @@ options:
         required: false
         type: str
     switching_profiles:
-        description: List of Switching Profile Names
+        description: List of Switching Profile Names and type
         required: false
         type: list
     transport_zone_name:
@@ -234,7 +234,7 @@ def update_params_with_id (module, manager_url, mgr_username, mgr_password, vali
     for switch_profile in switch_profiles or []:
         profile_obj = {}
         profile_obj['value'] = get_id_from_display_name (module, manager_url, mgr_username, mgr_password, validate_certs,
-                                                "/host-switch-profiles", switch_profile['name'])
+                                                "/switching-profiles", switch_profile['name'])
         profile_obj['key'] = switch_profile['type']
         switch_profile_ids.append(profile_obj)
     logical_switch_params['switching_profile_ids'] = switch_profile_ids


### PR DESCRIPTION
Problems existed with nsxt_logical_port and nsxt_logical_switches.
While converting switching-profile-name to id wrong api
endpoint was being used. The API endpoint is corrected now.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>