### PR TITLE
Unsupported param type boolean in nsxt_logical_switcches

### DIFF
--- a/library/nsxt_logical_switches.py
+++ b/library/nsxt_logical_switches.py
@@ -274,7 +274,7 @@ def main():
                         transport_zone_name=dict(required=True, type='str'),
                         ip_pool_name=dict(required=False, type='str'),
                         vlan=dict(required=False, type='int'),
-                        hybrid=dict(required=False, type='boolean'),
+                        hybrid=dict(required=False, type='bool'),
                         mac_pool_id=dict(required=False, type='str'),
                         vni=dict(required=False, type='int'),
                         vlan_trunk_spec=dict(required=False, type='dict',


### PR DESCRIPTION
Ansible doesn't have boolean type. The keyword for it is
bool. hybrid param in nsxt_logical_switches module had
param as boolean. Thus failing the parameter. Changed it
to bool.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>