### PR TITLE
Adding support for mac_pool_name in nsx_logical_switches

### DIFF
--- a/library/nsxt_logical_switches.py
+++ b/library/nsxt_logical_switches.py
@@ -89,6 +89,10 @@ options:
         description: Mac pool id that associated with a LogicalSwitch.
         required: false
         type: str
+    mac_pool_name:
+        description: Mac pool name that associated with a LogicalSwitch.
+        required: false
+        type: str
     replication_mode:
         description: Replication mode of the Logical Switch
         required: false
@@ -224,10 +228,15 @@ def update_params_with_id (module, manager_url, mgr_username, mgr_password, vali
         logical_switch_params['ip_pool_id'] = get_id_from_display_name (module, manager_url,
                                                                 mgr_username, mgr_password, validate_certs,
                                                                 "/pools/ip-pools", logical_switch_params.pop('ip_pool_name', None))
+    if 'mac_pool_name' in logical_switch_params and 'mac_pool_id' not in logical_switch_params:
+        logical_switch_params['mac_pool_id'] = get_id_from_display_name (module, manager_url,
+                                                                mgr_username, mgr_password, validate_certs,
+                                                                "/pools/mac-pools", logical_switch_params.pop('mac_pool_name', None))
+    if 'mac_pool_name' in logical_switch_params and 'mac_pool_id' in logical_switch_params:
+        logical_switch_params.pop('mac_pool_name', None)
     logical_switch_params['transport_zone_id'] = get_id_from_display_name (module, manager_url,
                                                                 mgr_username, mgr_password, validate_certs,
                                                                 "/transport-zones", logical_switch_params.pop('transport_zone_name', None))
-
     switch_profiles = logical_switch_params.pop('switching_profiles', None)
 
     switch_profile_ids = []
@@ -276,6 +285,7 @@ def main():
                         vlan=dict(required=False, type='int'),
                         hybrid=dict(required=False, type='bool'),
                         mac_pool_id=dict(required=False, type='str'),
+                        mac_pool_name=dict(required=False, type='str'),
                         vni=dict(required=False, type='int'),
                         vlan_trunk_spec=dict(required=False, type='dict',
                         vlan_ranges=dict(required=True, type='list')),


### PR DESCRIPTION
nsxt_logical_switches was using mac_pool_id. Added support for
mac_pool_name. If both mac_pool_id and mac_pool_name are given
priority is given to mac_pool_id.

Signed-off-by: Kommireddy Akhilesh<akhileshkommireddy2412@gmail.com>