### PR TITLE
Fix optional address_pool in Segment

### DIFF
--- a/library/nsxt_policy_segment.py
+++ b/library/nsxt_policy_segment.py
@@ -884,13 +884,15 @@ class NSXTSegment(NSXTBaseRealizableResource):
 
         if 'advanced_config' in nsx_resource_params and nsx_resource_params[
                 'advanced_config']:
+            address_pool_id = None
             if nsx_resource_params['advanced_config'][
                     'address_pool_id']:
                 address_pool_id = nsx_resource_params['advanced_config'].pop(
                     'address_pool_id')
                 nsx_resource_params['advanced_config'].pop(
                     'address_pool_display_name')
-            else:
+            elif nsx_resource_params['advanced_config'][
+                    'address_pool_display_name']:
                 address_pool_id = self.get_id_from_display_name(
                     IP_POOL_URL, nsx_resource_params['advanced_config'][
                         'address_pool_display_name'], "Ip Pool",
@@ -899,6 +901,11 @@ class NSXTSegment(NSXTBaseRealizableResource):
                     'address_pool_display_name')
                 nsx_resource_params['advanced_config'].pop(
                     'address_pool_id')
+            else:
+                nsx_resource_params['advanced_config'].pop(
+                    'address_pool_id')
+                nsx_resource_params['advanced_config'].pop(
+                    'address_pool_display_name')
             if address_pool_id:
                 address_pool_paths = [IP_POOL_URL + "/" + address_pool_id]
                 nsx_resource_params['advanced_config'][


### PR DESCRIPTION
address_pool can be specified as id or display_name. Since it's
optional, it can also not be specified. In the latter case, we
should not try to infer the address_pool_path

Issue: #253