### PR TITLE
Return error_code from policy-communicator upon failure

### DIFF
--- a/module_utils/nsxt_base_resource.py
+++ b/module_utils/nsxt_base_resource.py
@@ -665,7 +665,7 @@ class NSXTBaseRealizableResource(ABC):
                                                       self.id, to_native(err)),
                                   successfully_updated_resources=srel)
 
-    def _send_request_to_API(self, suffix="", ignore_error=True,
+    def _send_request_to_API(self, suffix="", ignore_error=False,
                              method='GET', data=None,
                              resource_base_url=None,
                              accepted_error_codes=set()):
@@ -683,6 +683,8 @@ class NSXTBaseRealizableResource(ABC):
                 resource_base_url + suffix,
                 ignore_errors=ignore_error, method=method, data=data)
             return (rc, resp)
+        except DuplicateRequestError:
+            self.module.fail_json(msg='Duplicate request')
         except Exception as e:
             if (e.args[0] not in accepted_error_codes and
                     self.get_resource_name() in BASE_RESOURCES):

--- a/module_utils/policy_communicator.py
+++ b/module_utils/policy_communicator.py
@@ -24,6 +24,7 @@ import hashlib
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.vmware_nsxt import get_certificate_file_path
+from ansible.module_utils.vmware_nsxt import is_json
 
 
 class PolicyCommunicator:
@@ -142,11 +143,11 @@ class PolicyCommunicator:
             try:
                 resp_data = resp_raw_data
                 # infer the response
-                if resp_raw_data:
+                if resp_raw_data and is_json(resp_raw_data):
                     resp_data = json.loads(resp_raw_data)
             except Exception as e:
                 if not ignore_errors:
-                    raise Exception(resp_raw_data)
+                    raise Exception(resp_code, resp_raw_data)
 
             # return the approprate response code and data
             if resp_code >= 400 and not ignore_errors:


### PR DESCRIPTION
policy_communicator module should always raise an Exception that has
args of form (return_code, data)

Issue: #267

Signed-off-by: Gautam Verma <vermag@vmware.com>
Signed-off-by: Gautam Verma <gautam94verma@gmail.com>