### PR TITLE
Make documentation parseable

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,2 @@
 [defaults]
 hostfile = hosts/hosts
-library = library:./library
-module_utils = module_utils:./module_utils

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,4 @@
 [defaults]
 hostfile = hosts/hosts
+library = library:./library
+module_utils = module_utils:./module_utils

--- a/library/nsxt_certificates.py
+++ b/library/nsxt_certificates.py
@@ -23,11 +23,12 @@ DOCUMENTATION = '''
 ---
 module: nsxt_certificates
 short_description: 'Add a New Certificate'
-description: "Adds a new private-public certificate or a chain of certificates (CAs) and, 
-              optionally, a private key that can be applied to one of the user-facing 
-              components (appliance management or edge). The certificate and the key 
-              should be stored in PEM format. If no private key is provided, the 
-              certificate is used as a client certificate in the trust store."
+description: 
+  - "Adds a new private-public certificate or a chain of certificates (CAs) and, 
+    optionally, a private key that can be applied to one of the user-facing 
+    components (appliance management or edge)."
+  - The certificate and the key should be stored in PEM format. 
+  - If no private key is provided, the certificate is used as a client certificate in the trust store.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:
@@ -87,7 +88,6 @@ options:
                       'present' is used to create or update resource.
                       'absent' is used to delete resource."
         required: true
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_certificates.py
+++ b/library/nsxt_certificates.py
@@ -44,13 +44,13 @@ options:
         required: true
         type: str
     display_name:
-        description:'Identifier to use when displaying entity in logs or GUI'
+        description: 'Identifier to use when displaying entity in logs or GUI'
         required: true
         type: str
     pem_encoded_file:
         description: 'File containing pem encoded certificate data'
         required: true
-        type='str' 
+        type: 'str' 
     private_key_file:
         description: 'File containing private key data'
         required: false

--- a/library/nsxt_certificates_facts.py
+++ b/library/nsxt_certificates_facts.py
@@ -23,12 +23,13 @@ DOCUMENTATION = '''
 ---
 module: nsxt_certificates_facts
 short_description: List all existing certificates
-description: Returns all certificate information viewable by the user, including each
-             certificate's UUID; resource_type (for example, certificate_self_signed,
-             certificate_ca, or certificate_signed); pem_encoded data; and history of the
-             certificate (who created or modified it and when). For additional
-             information, include the ?details=true modifier at the end of the request
-             URI.
+description: 
+  - Returns all certificate information viewable by the user, including each
+    certificate's UUID; resource_type (for example, certificate_self_signed,
+    certificate_ca, or certificate_signed); pem_encoded data; and history of the
+    certificate (who created or modified it and when). For additional
+    information, include the ?details=true modifier at the end of the request
+    URI.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:
@@ -44,8 +45,6 @@ options:
         description: The password to authenticate with the NSX manager.
         required: true
         type: str
-
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_compute_collection_fabric_templates.py
+++ b/library/nsxt_compute_collection_fabric_templates.py
@@ -52,7 +52,7 @@ options:
         required: false
         type: str
     compute_manager_name:
-        description: 'Cluster Manager's Name'
+        description: "Cluster Manager's Name"
         required: false
         type: str
     display_name:

--- a/library/nsxt_compute_collection_fabric_templates.py
+++ b/library/nsxt_compute_collection_fabric_templates.py
@@ -23,9 +23,9 @@ DOCUMENTATION = '''
 ---
 module: nsxt_compute_collection_fabric_templates
 short_description: 'Create a compute collection fabric template'
-description: 'Fabric templates are fabric configurations applied at the compute collection 
-              level. This configurations is used to decide what automated operations should 
-              be a run when a host membership changes.'
+description: 
+    - Fabric templates are fabric configurations applied at the compute collection level.
+    - This configurations is used to decide what automated operations should be a run when a host membership changes.
 version_added: '2.7'
 author: 'Rahul Raghuvanshi'
 options:
@@ -67,7 +67,6 @@ options:
                       'present' is used to create or update resource.
                       'absent' is used to delete resource."
         required: true
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_compute_collection_fabric_templates_facts.py
+++ b/library/nsxt_compute_collection_fabric_templates_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_compute_collection_fabric_templates_facts
 short_description: 'Get compute collection fabric templates'
-description: 'Returns compute collection fabric templates'
+description: 
+  - Returns compute collection fabric templates.
 version_added: '2.7'
 author: 'Rahul Raghuvanshi'
 options:
@@ -39,7 +40,6 @@ options:
         description: 'The password to authenticate with the NSX manager.'
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_compute_collection_transport_templates_facts.py
+++ b/library/nsxt_compute_collection_transport_templates_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_compute_collection_transport_templates_facts
 short_description: 'List compute collection transportnode templates'
-description: 'Returns all eligible compute collection transportnode templates'
+description: 
+  - Returns all eligible compute collection transportnode templates.
 version_added: '2.7'
 author: 'Rahul Raghuvanshi'
 options:
@@ -39,7 +40,6 @@ options:
         description: 'The password to authenticate with the NSX manager.'
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_deploy_ova.py
+++ b/library/nsxt_deploy_ova.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_deploy_ova
 short_description: Deploys NSXT Manager
-description: Deploys NSXT Manager
+description: 
+    - Deploys NSXT Manager.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:

--- a/library/nsxt_deploy_ova.py
+++ b/library/nsxt_deploy_ova.py
@@ -41,7 +41,7 @@ options:
         type: str
     ovftool_path:
         description: Path of ovf tool
-        type: 'str',
+        type: 'str'
     folder:
         description:  vCenter folder
         required: false

--- a/library/nsxt_edge_clusters.py
+++ b/library/nsxt_edge_clusters.py
@@ -23,12 +23,13 @@ DOCUMENTATION = '''
 ---
 module: nsxt_edge_clusters
 short_description: 'Create Edge Cluster'
-description: "Creates a new edge cluster.
-              It only supports homogeneous members.
-              The TransportNodes backed by EdgeNode are only allowed in cluster members.
-              DeploymentType (VIRTUAL_MACHINE|PHYSICAL_MACHINE) of these EdgeNodes is
-              recommended to be the same. EdgeCluster supports members of different
-              deployment types."
+description: 
+    - Creates a new edge cluster.
+    - It only supports homogeneous members.
+    - The TransportNodes backed by EdgeNode are only allowed in cluster members.
+    - DeploymentType (VIRTUAL_MACHINE|PHYSICAL_MACHINE) of these EdgeNodes is
+      recommended to be the same. 
+    - EdgeCluster supports members of different deployment types.
 version_added: '2.7'
 author: 'Rahul Raghuvanshi'
 options:
@@ -101,8 +102,6 @@ options:
                       'present' is used to create or update resource.
                       'absent' is used to delete resource."
         required: true
-
-    
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_edge_clusters_facts.py
+++ b/library/nsxt_edge_clusters_facts.py
@@ -23,10 +23,11 @@ DOCUMENTATION = '''
 ---
 module: nsxt_edge_clusters_facts
 short_description: List Edge Clusters
-description: Returns information about the configured edge clusters, which enable you to
-             group together transport nodes of the type EdgeNode and apply fabric
-             profiles to all members of the edge cluster. Each edge node can participate
-             in only one edge cluster.
+description: 
+  - Returns information about the configured edge clusters, which enable you to
+    group together transport nodes of the type EdgeNode and apply fabric
+    profiles to all members of the edge cluster. 
+  - Each edge node can participate in only one edge cluster.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_fabric_compute_managers.py
+++ b/library/nsxt_fabric_compute_managers.py
@@ -23,8 +23,9 @@ DOCUMENTATION = '''
 ---
 module: nsxt_fabric_compute_managers
 short_description: 'Register compute manager with NSX'
-description: "Registers compute manager with NSX. Inventory service will collect
-              data from the registered compute manager"
+description:
+    - Registers compute manager with NSX. 
+    - Inventory service will collect data from the registered compute manager.
 version_added: '2.7'
 author: 'Rahul Raghuvanshi'
 options:
@@ -100,8 +101,6 @@ options:
                       'present' is used to create or update resource.
                       'absent' is used to delete resource."
         required: true
-
-    
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_fabric_compute_managers_facts.py
+++ b/library/nsxt_fabric_compute_managers_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_fabric_compute_managers_facts
 short_description: Return the List of Compute managers
-description: Returns information about all compute managers.
+description: 
+  - Returns information about all compute managers.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:
@@ -39,7 +40,6 @@ options:
         description: The password to authenticate with the NSX manager.
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_fabric_nodes.py
+++ b/library/nsxt_fabric_nodes.py
@@ -24,36 +24,34 @@ DOCUMENTATION = '''
 ---
 module: nsxt_fabric_nodes
 short_description: Register and Install NSX Components on a Node
-description: Creates a host node (hypervisor) or edge node (router) in the transport
-             network.
+description: 
+    - Creates a host node (hypervisor) or edge node (router) in the transport network.
 
-             When you run this command for a host, NSX Manager attempts to install the
-             NSX kernel modules, which are packaged as VIB, RPM, or DEB files. For the
-             installation to succeed, you must provide the host login credentials and the
-             host thumbprint.
+    - When you run this command for a host, NSX Manager attempts to install the
+      NSX kernel modules, which are packaged as VIB, RPM, or DEB files.
 
-             To get the ESXi host thumbprint, SSH to the host and run the
-             'openssl x509 -in /etc/vmware/ssl/rui.crt -fingerprint -sha256 -noout'
-             command.
+    - For the installation to succeed, you must provide the host login credentials and the
+      host thumbprint.
 
-             To generate host key thumbprint using SHA-256 algorithm please follow the
-             steps below.
+    - To get the ESXi host thumbprint, SSH to the host and run the
+      'openssl x509 -in /etc/vmware/ssl/rui.crt -fingerprint -sha256 -noout'
+      command.
+    - To generate host key thumbprint using SHA-256 algorithm please follow the steps below.
 
-             Log into the host, making sure that the connection is not vulnerable to a
-             man in the middle attack. Check whether a public key already exists.
-             Host public key is generally located at '/etc/ssh/ssh_host_rsa_key.pub'.
-             If the key is not present then generate a new key by running the following
-             command and follow the instructions.
+    - Log into the host, making sure that the connection is not vulnerable to a
+      man in the middle attack. Check whether a public key already exists.
+      Host public key is generally located at '/etc/ssh/ssh_host_rsa_key.pub'.
+      If the key is not present then generate a new key by running the following
+      command and follow the instructions.
+    - ssh-keygen -t rsa
 
-             <b>ssh-keygen -t rsa</b>
+    - Now generate a SHA256 hash of the key using the following command. Please
+      make sure to pass the appropriate file name if the public key is stored with
+      a different file name other than the default 'id_rsa.pub'.
 
-             Now generate a SHA256 hash of the key using the following command. Please
-             make sure to pass the appropriate file name if the public key is stored with
-             a different file name other than the default 'id_rsa.pub'.
-
-             <b>awk '{print $2}' id_rsa.pub | base64 -d | sha256sum -b | sed 's/ .*$//' | xxd -r -p | base64</b>
-             This api is deprecated as part of FN+TN unification. Please use Transport Node API
-             to install NSX components on a node.
+    - awk '{print $2}' id_rsa.pub | base64 -d | sha256sum -b | sed 's/ .*$//' | xxd -r -p | base64
+    - This api is deprecated as part of FN+TN unification. Please use Transport Node API
+      to install NSX components on a node.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_fabric_nodes.py
+++ b/library/nsxt_fabric_nodes.py
@@ -33,7 +33,7 @@ description: Creates a host node (hypervisor) or edge node (router) in the trans
              host thumbprint.
 
              To get the ESXi host thumbprint, SSH to the host and run the
-             <b>openssl x509 -in /etc/vmware/ssl/rui.crt -fingerprint -sha256 -noout</b>
+             'openssl x509 -in /etc/vmware/ssl/rui.crt -fingerprint -sha256 -noout'
              command.
 
              To generate host key thumbprint using SHA-256 algorithm please follow the
@@ -96,8 +96,8 @@ options:
                 required: false
                 type: str
             audit_username:
-                description: "The default username is \"audit\". To configure username, you must 
-                              provide this property together with <b>audit_password</b>."
+                description: "The default username is 'audit'. To configure username, you must 
+                              provide this property together with 'audit_password'."
                 required: false
                 type: str
             cli_password:
@@ -112,7 +112,7 @@ options:
                 type: str
             cli_username:
                 description: "To configure username, you must provide this property together 
-                              with <b>cli_password</b>."
+                              with 'cli_password'."
                 required: false
                 type: str
             description: "Username and password settings for the node.

--- a/library/nsxt_fabric_nodes_facts.py
+++ b/library/nsxt_fabric_nodes_facts.py
@@ -23,9 +23,10 @@ DOCUMENTATION = '''
 ---
 module: nsxt_fabric_nodes_facts
 short_description: Return the List of Nodes
-description: Returns information about all fabric nodes (hosts and edges).
-             This api is deprecated as part of FN+TN unification. Please use GET Transport Node
-             API to list all fabric nodes.
+description: 
+  - Returns information about all fabric nodes (hosts and edges).
+  - This api is deprecated as part of FN+TN unification. 
+  - Please use GET Transport Node API to list all fabric nodes.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:
@@ -41,7 +42,6 @@ options:
         description: The password to authenticate with the NSX manager.
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_ip_blocks.py
+++ b/library/nsxt_ip_blocks.py
@@ -22,8 +22,10 @@ DOCUMENTATION = '''
 ---
 module: nsxt_ip_blocks
 short_description: 'Create a new IP address block.'
-description: "Creates a new IPv4 address block using the specified cidr. cidr is a
-              required parameter. display_name & description are optional parameters"
+description: 
+    - "Creates a new IPv4 address block using the specified cidr. 
+    - cidr is a required parameter. 
+    - display_name & description are optional parameters.
 version_added: '2.7'
 author: 'Rahul Raghuvanshi'
 options:

--- a/library/nsxt_ip_blocks.py
+++ b/library/nsxt_ip_blocks.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 module: nsxt_ip_blocks
 short_description: 'Create a new IP address block.'
 description: 
-    - "Creates a new IPv4 address block using the specified cidr. 
+    - Creates a new IPv4 address block using the specified cidr. 
     - cidr is a required parameter. 
     - display_name & description are optional parameters.
 version_added: '2.7'

--- a/library/nsxt_ip_blocks_facts.py
+++ b/library/nsxt_ip_blocks_facts.py
@@ -30,9 +30,9 @@ DOCUMENTATION = '''
 ---
 module: nsxt_ip_blocks_facts
 short_description: Returns list of configured IP address blocks.
-description: Returns information about configured IP address blocks. Information includes
-             the id, display name, description & CIDR of IP address blocks
-
+description: 
+  - Returns information about configured IP address blocks. 
+  - Information includes the id, display name, description & CIDR of IP address blocks.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:
@@ -48,7 +48,6 @@ options:
         description: The password to authenticate with the NSX manager.
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_ip_pools.py
+++ b/library/nsxt_ip_pools.py
@@ -22,9 +22,10 @@ DOCUMENTATION = '''
 ---
 module: nsxt_ip_pools
 short_description: 'Create an IP Pool'
-description: "Creates a new IPv4 or IPv6 address pool. Required parameters are
-              allocation_ranges and cidr. Optional parameters are display_name,
-              description, dns_nameservers, dns_suffix, and gateway_ip."
+description: 
+    - Creates a new IPv4 or IPv6 address pool. 
+    - Required parameters are allocation_ranges and cidr. 
+    - Optional parameters are display_name, description, dns_nameservers, dns_suffix, and gateway_ip.
 version_added: '2.7'
 author: 'Rahul Raghuvanshi'
 options:
@@ -69,8 +70,6 @@ options:
         description: 'IP address release delay'
         required: false
         type: int
-
-    
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_ip_pools_facts.py
+++ b/library/nsxt_ip_pools_facts.py
@@ -23,10 +23,11 @@ DOCUMENTATION = '''
 ---
 module: nsxt_ip_pools_facts
 short_description: List IP Pools
-description: Returns information about the configured IP address pools. Information
-             includes the display name and description of the pool and the details of
-             each of the subnets in the pool, including the DNS servers, allocation
-             ranges, gateway, and CIDR subnet address.
+description: 
+  - Returns information about the configured IP address pools. 
+  - Information includes the display name and description of the pool and the details of
+    each of the subnets in the pool, including the DNS servers, allocation
+    ranges, gateway, and CIDR subnet address.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi
@@ -43,7 +44,6 @@ options:
         description: The password to authenticate with the NSX manager.
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_licenses.py
+++ b/library/nsxt_licenses.py
@@ -23,11 +23,13 @@ DOCUMENTATION = '''
 ---
 module: nsxt_licenses
 short_description: 'Add a new license key'
-description: "This will add a license key to the system.
-              The API supports adding only one license key for each license edition
-              type - Standard, Advanced or Enterprise. If a new license key is tried
-              to add for an edition for which the license key already exists,
-              then this API will return an error."
+description: 
+    - This will add a license key to the system.
+    - The API supports adding only one license key for each license edition
+      type - Standard, Advanced or Enterprise. 
+    - If a new license key is tried
+      to add for an edition for which the license key already exists,
+      then this API will return an error. 
 version_added: '2.7'
 author: 'Rahul Raghuvanshi'
 options:

--- a/library/nsxt_licenses_facts.py
+++ b/library/nsxt_licenses_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_licenses_facts
 short_description: Get all licenses
-description: Returns all licenses.
+description: 
+  - Returns all licenses.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi
@@ -40,7 +41,6 @@ options:
         description: The password to authenticate with the NSX manager.
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_logical_ports.py
+++ b/library/nsxt_logical_ports.py
@@ -23,14 +23,14 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_ports
 short_description: Create a Logical Port
-description: Creates a new logical switch port. The required parameters are the
+description: "Creates a new logical switch port. The required parameters are the
 associated logical_switch_id and admin_state (UP or DOWN). Optional
 parameters are the attachment and switching_profile_ids. If you don't
 specify switching_profile_ids, default switching profiles are assigned to
 the port. If you don't specify an attachment, the switch port remains
 empty. To configure an attachment, you must specify an id, and
 optionally you can specify an attachment_type (VIF or LOGICALROUTER).
-The attachment_type is VIF by default.
+The attachment_type is VIF by default."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_logical_ports.py
+++ b/library/nsxt_logical_ports.py
@@ -23,14 +23,14 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_ports
 short_description: Create a Logical Port
-description: "Creates a new logical switch port. The required parameters are the
-associated logical_switch_id and admin_state (UP or DOWN). Optional
-parameters are the attachment and switching_profile_ids. If you don't
-specify switching_profile_ids, default switching profiles are assigned to
-the port. If you don't specify an attachment, the switch port remains
-empty. To configure an attachment, you must specify an id, and
-optionally you can specify an attachment_type (VIF or LOGICALROUTER).
-The attachment_type is VIF by default."
+description: 
+    - Creates a new logical switch port. 
+    - The required parameters are the associated logical_switch_id and admin_state (UP or DOWN). 
+    - Optional parameters are the attachment and switching_profile_ids. 
+    - If you don't specify switching_profile_ids, default switching profiles are assigned to the port. 
+    - If you don't specify an attachment, the switch port remains empty. 
+    - To configure an attachment, you must specify an id, and optionally you can specify an attachment_type (VIF or LOGICALROUTER).
+    - The attachment_type is VIF by default.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_logical_ports_facts.py
+++ b/library/nsxt_logical_ports_facts.py
@@ -23,10 +23,10 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_ports_facts
 short_description: List All Logical Ports
-description: Returns information about all configured logical switch ports. Logical
-             switch ports connect to VM virtual network interface cards (NICs). Each
-             logical port is associated with one logical switch.
-
+description: 
+  - Returns information about all configured logical switch ports. 
+  - Logical switch ports connect to VM virtual network interface cards (NICs). 
+  - Each logical port is associated with one logical switch.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:
@@ -42,7 +42,6 @@ options:
         description: The password to authenticate with the NSX manager.
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_logical_router_ports.py
+++ b/library/nsxt_logical_router_ports.py
@@ -23,11 +23,11 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_router_ports
 short_description: Create a Logical Router Port
-description: Creates a logical router port. The required parameters include resource_type
+description: "Creates a logical router port. The required parameters include resource_type
 (LogicalRouterUpLinkPort, LogicalRouterDownLinkPort, LogicalRouterLinkPort,
 LogicalRouterLoopbackPort, LogicalRouterCentralizedServicePort); and
 logical_router_id (the router to which each logical router port is assigned).
-The service_bindings parameter is optional.
+The service_bindings parameter is optional."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_logical_router_ports.py
+++ b/library/nsxt_logical_router_ports.py
@@ -23,11 +23,12 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_router_ports
 short_description: Create a Logical Router Port
-description: "Creates a logical router port. The required parameters include resource_type
-(LogicalRouterUpLinkPort, LogicalRouterDownLinkPort, LogicalRouterLinkPort,
-LogicalRouterLoopbackPort, LogicalRouterCentralizedServicePort); and
-logical_router_id (the router to which each logical router port is assigned).
-The service_bindings parameter is optional."
+description: 
+    - Creates a logical router port. 
+    - The required parameters include resource_type (LogicalRouterUpLinkPort, LogicalRouterDownLinkPort, LogicalRouterLinkPort,
+      LogicalRouterLoopbackPort, LogicalRouterCentralizedServicePort); 
+    - and logical_router_id (the router to which each logical router port is assigned).
+    - The service_bindings parameter is optional.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi
@@ -359,7 +360,6 @@ options:
         description: Opaque identifiers meaningful to the API user
         required: False
         type: list
-    
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_logical_router_ports_facts.py
+++ b/library/nsxt_logical_router_ports_facts.py
@@ -23,14 +23,13 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_router_ports_facts
 short_description: List Logical Router Ports
-description: Returns information about all logical router ports. Information includes the
-              resource_type (LogicalRouterUpLinkPort, LogicalRouterDownLinkPort,
-              LogicalRouterLinkPort, LogicalRouterLoopbackPort, 
-              LogicalRouterCentralizedServicePort);
-              logical_router_id (the router to which each logical router port is assigned);
-              and any service_bindings (such as DHCP relay service).
-              The GET request can include a query parameter (logical_router_id
-              or logical_switch_id).
+description: 
+  - Returns information about all logical router ports. 
+  - Information includes the resource_type (LogicalRouterUpLinkPort, LogicalRouterDownLinkPort,
+    LogicalRouterLinkPort, LogicalRouterLoopbackPort, LogicalRouterCentralizedServicePort);
+    logical_router_id (the router to which each logical router port is assigned);
+    and any service_bindings (such as DHCP relay service).
+  - The GET request can include a query parameter (logical_router_id or logical_switch_id).
 
 version_added: "2.7"
 author: Rahul Raghuvanshi
@@ -47,7 +46,6 @@ options:
         description: The password to authenticate with the NSX manager.
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_logical_router_static_routes.py
+++ b/library/nsxt_logical_router_static_routes.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_router_static_routes
 short_description: Add Static Routes on a Logical Router
-description: Add Static Routes on a Logical Router
+description: 
+  - Add Static Routes on a Logical Router
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:
@@ -75,7 +76,6 @@ options:
                       'present' is used to create or update resource. 
                       'absent' is used to delete resource."
         required: true
-    
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_logical_routers.py
+++ b/library/nsxt_logical_routers.py
@@ -23,10 +23,10 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_routers
 short_description: Create a Logical Router
-description: Creates a logical router. The required parameters are router_type (TIER0 or
-             TIER1) and edge_cluster_id (TIER0 only). Optional parameters include
-             internal and external transit network addresses.
-
+description: 
+    - Creates a logical router. The required parameters are router_type (TIER0 or
+      TIER1) and edge_cluster_id (TIER0 only). 
+    - Optional parameters include internal and external transit network addresses.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:
@@ -185,7 +185,6 @@ options:
                       'present' is used to create or update resource. 
                       'absent' is used to delete resource."
         required: true
-    
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_logical_routers_facts.py
+++ b/library/nsxt_logical_routers_facts.py
@@ -23,10 +23,12 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_routers_facts
 short_description: List Logical Routers
-description: Returns information about all logical routers, including the UUID, internal
-              and external transit network addresses, and the router type (TIER0 or
-              TIER1). You can get information for only TIER0 routers or only the TIER1
-              routers by including the router_type query parameter.
+description: 
+  - Returns information about all logical routers, including the UUID, internal
+    and external transit network addresses, and the router type (TIER0 or
+    TIER1). 
+  - You can get information for only TIER0 routers or only the TIER1 
+    routers by including the router_type query parameter.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi
@@ -43,7 +45,6 @@ options:
         description: The password to authenticate with the NSX manager.
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_logical_switches.py
+++ b/library/nsxt_logical_switches.py
@@ -23,12 +23,12 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_switches
 short_description: Create a Logical Switch
-description: Creates a new logical switch. The request must include the
-             transport_zone_id, display_name, and admin_state (UP or DOWN). The
-             replication_mode (MTEP or SOURCE) is required for overlay logical
-             switches, but not for VLAN-based logical switches. A vlan needs to be
-             provided for VLAN-based logical switches
-
+description: 
+    - Creates a new logical switch. 
+    - The request must include the transport_zone_id, display_name, and admin_state (UP or DOWN). 
+    - The replication_mode (MTEP or SOURCE) is required for overlay logical
+      switches, but not for VLAN-based logical switches. 
+    - A vlan needs to be provided for VLAN-based logical switches.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:

--- a/library/nsxt_logical_switches_facts.py
+++ b/library/nsxt_logical_switches_facts.py
@@ -39,7 +39,6 @@ options:
         description: The password to authenticate with the NSX manager.
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_manager_auto_deployment.py
+++ b/library/nsxt_manager_auto_deployment.py
@@ -23,9 +23,9 @@ DOCUMENTATION = '''
 ---
 module: nsxt_manager_auto_deployment
 short_description: 'Deploy and register a cluster node VM'
-description: "Deploys a cluster node VM as specified by the deployment config.
-              Once the VM is deployed and powered on, it will automatically join the
-              existing cluster."
+description: 
+  - Deploys a cluster node VM as specified by the deployment config.
+  - Once the VM is deployed and powered on, it will automatically join the existing cluster.
 version_added: '2.7'
 author: 'Rahul Raghuvanshi'
 options:
@@ -61,7 +61,6 @@ options:
                       'present' is used to create or update resource.
                       'absent' is used to delete resource."
         required: true
-    
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_manager_auto_deployment_facts.py
+++ b/library/nsxt_manager_auto_deployment_facts.py
@@ -22,8 +22,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 module: nsxt_manager_auto_deployment_facts
 short_description: 'Returns info for all cluster node VM auto-deployment attempts'
-description: 'Returns request information for every attempted deployment of a 
-              cluster node VM'
+description: 
+  - Returns request information for every attempted deployment of a cluster node VM.
 version_added: '2.7'
 author: 'Rahul Raghuvanshi'
 options:

--- a/library/nsxt_manager_status.py
+++ b/library/nsxt_manager_status.py
@@ -23,8 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_manager_status
 short_description: Shows status of nsxt manager
-description: Shows status of nsxt manager
-
+description: 
+  - Shows status of nsxt manager.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:

--- a/library/nsxt_policy_bfd_config.py
+++ b/library/nsxt_policy_bfd_config.py
@@ -28,12 +28,10 @@ DOCUMENTATION = '''
 ---
 module: nsxt_policy_bfd_config
 short_description: Create or Delete a Policy BFD Config
-description:
-    Creates or deletes a Policy BFD Config.
-    Required attributes include id and display_name.
+description: "Creates or deletes a Policy BFD Config.
+    Required attributes include id and display_name."
 version_added: "2.8"
 author: Gautam Verma
-extends_documentation_fragment: vmware_nsxt
 options:
     hostname:
         description: Deployed NSX manager hostname.

--- a/library/nsxt_policy_bfd_config.py
+++ b/library/nsxt_policy_bfd_config.py
@@ -28,8 +28,9 @@ DOCUMENTATION = '''
 ---
 module: nsxt_policy_bfd_config
 short_description: Create or Delete a Policy BFD Config
-description: "Creates or deletes a Policy BFD Config.
-    Required attributes include id and display_name."
+description:
+    - Creates or deletes a Policy BFD Config.
+    - Required attributes include id and display_name.
 version_added: "2.8"
 author: Gautam Verma
 options:

--- a/library/nsxt_policy_group.py
+++ b/library/nsxt_policy_group.py
@@ -29,8 +29,8 @@ DOCUMENTATION = '''
 module: nsxt_policy_group
 short_description: Create or Delete a Policy Policy Group
 description:
-    Creates or deletes a Policy Policy Group.
-    Required attributes include id and display_name.
+    - Creates or deletes a Policy Policy Group.
+    - Required attributes include id and display_name.
 version_added: "2.8"
 author: Gautam Verma
 options:

--- a/library/nsxt_policy_ip_block.py
+++ b/library/nsxt_policy_ip_block.py
@@ -29,8 +29,8 @@ DOCUMENTATION = '''
 module: nsxt_policy_ip_block
 short_description: Create or Delete a Policy IP Block
 description:
-    Creates or deletes a Policy IP Block.
-    Required attributes include id and display_name.
+    - Creates or deletes a Policy IP Block.
+    - Required attributes include id and display_name.
 version_added: "2.8"
 author: Gautam Verma
 options:

--- a/library/nsxt_policy_ip_pool.py
+++ b/library/nsxt_policy_ip_pool.py
@@ -29,8 +29,8 @@ DOCUMENTATION = '''
 module: nsxt_policy_ip_pool
 short_description: Create or Delete a Policy IP Pool
 description:
-    Creates or deletes a Policy IP Pool.
-    Required attributes include id and display_name.
+    - Creates or deletes a Policy IP Pool.
+    - Required attributes include id and display_name.
 version_added: "2.8"
 author: Gautam Verma
 options:

--- a/library/nsxt_policy_security_policy.py
+++ b/library/nsxt_policy_security_policy.py
@@ -29,8 +29,8 @@ DOCUMENTATION = '''
 module: nsxt_policy_security_policy
 short_description: Create or Delete a Policy Security Policy
 description:
-    Creates or deletes a Policy Security Policy.
-    Required attributes include id and display_name.
+    - Creates or deletes a Policy Security Policy.
+    - Required attributes include id and display_name.
 version_added: "2.8"
 author: Gautam Verma
 options:

--- a/library/nsxt_policy_segment.py
+++ b/library/nsxt_policy_segment.py
@@ -29,9 +29,9 @@ DOCUMENTATION = '''
 module: nsxt_policy_segment
 short_description: Create or Delete a Policy Segment
 description:
-    Creates or deletes a Policy Segment.
-    Required attributes include id and display_name.
-    If the specified TransportZone is of VLAN type, a vlan_id is also required.
+    - Creates or deletes a Policy Segment.
+    - Required attributes include id and display_name.
+    - If the specified TransportZone is of VLAN type, a vlan_id is also required.
 version_added: "2.8"
 author: Gautam Verma
 options:

--- a/library/nsxt_policy_tier0.py
+++ b/library/nsxt_policy_tier0.py
@@ -27,11 +27,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 module: nsxt_policy_tier0
 short_description: 'Create/Update/Delete a Tier-0 and associated resources'
-description: Creates/Updates/Deletes a Tier-0 resource using the Policy API.
-             Assocaited resources include 'Tier-0 Locale Service' and
-             'Tier-0 Interface'. 'Tier-0 Locale Service' and 'Tier-0 Interface'
-             attributes must be prepended with 't0ls' and 't0iface'
-             respectively.
+description: 
+    - Creates/Updates/Deletes a Tier-0 resource using the Policy API.
+    - "Assocaited resources include 'Tier-0 Locale Service' and 'Tier-0 Interface'."
+    - "'Tier-0 Locale Service' and 'Tier-0 Interface' attributes must be prepended with 't0ls' and 't0iface'
+       respectively."
 version_added: '2.8'
 author: 'Gautam Verma'
 options:

--- a/library/nsxt_policy_tier1.py
+++ b/library/nsxt_policy_tier1.py
@@ -27,11 +27,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 module: nsxt_policy_tier1
 short_description: 'Create/Update/Delete a Tier-1 and associated resources'
-description: Creates/Updates/Deletes a Tier-1 resource using the Policy API.
-             Assocaited resources include 'Tier-1 Locale Service' and
-             'Tier-1 Interface'. 'Tier-1 Locale Service' and 'Tier-1 Interface'
-             attributes must be prepended with 't1ls' and 't1iface'
-             respectively.
+description: 
+    - Creates/Updates/Deletes a Tier-1 resource using the Policy API.
+    - "Assocaited resources include 'Tier-1 Locale Service' and 'Tier-1 Interface'."
+    - "'Tier-1 Locale Service' and 'Tier-1 Interface' attributes must be prepended with 't1ls' and 't1iface'
+       respectively."
 version_added: '2.8'
 author: 'Gautam Verma'
 options:

--- a/library/nsxt_principal_identities.py
+++ b/library/nsxt_principal_identities.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_principal_identities
 short_description: 'Register a name-certificate combination.'
-description: "Associates a principal's name with a certificate that is used to authenticate. "
+description: 
+  - Associates a principal's name with a certificate that is used to authenticate.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_principal_identities_facts.py
+++ b/library/nsxt_principal_identities_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_principal_identities_facts
 short_description: List all existing principal identities
-description: Returns the list of principals registered with a certificate.
+description: 
+  - Returns the list of principals registered with a certificate.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:

--- a/library/nsxt_repo_sync.py
+++ b/library/nsxt_repo_sync.py
@@ -23,10 +23,10 @@ DOCUMENTATION = '''
 ---
 module: nsxt_repo_sync
 short_description: 'Synchronizes the repository data between nsx managers'
-description: "Attempts to synchronize the repository partition on nsx 
-              manager. Repository partition contains packages required for 
-              the install and upgrade of nsx components.Normally 
-              there is no need to call this API explicitely by the user."
+description: 
+  - Attempts to synchronize the repository partition on nsx manager.
+  - Repository partition contains packages required for the install and upgrade of nsx components.
+  - Normally there is no need to call this API explicitely by the user.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_repo_sync_facts.py
+++ b/library/nsxt_repo_sync_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_repo_sync_facts
 short_description: 'Get synchronize status of a manager node'
-description: "Returns the synchronization status for the manager represented by given ."
+description: 
+  - Returns the synchronization status for the manager represented by given.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_transport_node_collections.py
+++ b/library/nsxt_transport_node_collections.py
@@ -23,11 +23,11 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_node_collections
 short_description: Create transport node collection by attaching Transport Node Profile to cluster.
-description: When transport node collection is created the hosts which are part
+description: "When transport node collection is created the hosts which are part
 of compute collection will be prepared automatically i.e. NSX Manager
 attempts to install the NSX components on hosts. Transport nodes for these
 hosts are created using the configuration specified in transport node
-profile.
+profile."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_transport_node_collections.py
+++ b/library/nsxt_transport_node_collections.py
@@ -23,11 +23,12 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_node_collections
 short_description: Create transport node collection by attaching Transport Node Profile to cluster.
-description: "When transport node collection is created the hosts which are part
-of compute collection will be prepared automatically i.e. NSX Manager
-attempts to install the NSX components on hosts. Transport nodes for these
-hosts are created using the configuration specified in transport node
-profile."
+description: 
+    - When transport node collection is created the hosts which are part
+      of compute collection will be prepared automatically i.e. NSX Manager
+      attempts to install the NSX components on hosts. 
+    - Transport nodes for these hosts are created using the configuration 
+      specified in transport node profile.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi
@@ -83,7 +84,6 @@ options:
         description: Transport Node Profile Names
         required: true
         type: str
-    
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_transport_node_collections_facts.py
+++ b/library/nsxt_transport_node_collections_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_node_collections_facts
 short_description: List Transport Node collections
-description: Returns all Transport Node collections
+description: 
+  - Returns all Transport Node collections.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:
@@ -39,7 +40,6 @@ options:
         description: The password to authenticate with the NSX manager.
         required: true
         type: str
-
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_transport_node_profiles.py
+++ b/library/nsxt_transport_node_profiles.py
@@ -23,9 +23,9 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_node_profiles
 short_description: "Create a Transport Node Profile"
-description: "Transport node profile captures the configuration needed to create
-a transport node. A transport node profile can be attached to
-compute collections for automatic TN creation of member hosts."
+description: 
+    - Transport node profile captures the configuration needed to create a transport node. 
+    - A transport node profile can be attached to compute collections for automatic TN creation of member hosts.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi
@@ -80,7 +80,6 @@ options:
         description: Transport zone endpoints.
         required: False
         type: array of TransportZoneEndPoint
-    
 '''
 
 EXAMPLES = '''

--- a/library/nsxt_transport_node_profiles.py
+++ b/library/nsxt_transport_node_profiles.py
@@ -22,10 +22,10 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: nsxt_transport_node_profiles
-short_description: Create a Transport Node Profile
-description: Transport node profile captures the configuration needed to create
+short_description: "Create a Transport Node Profile"
+description: "Transport node profile captures the configuration needed to create
 a transport node. A transport node profile can be attached to
-compute collections for automatic TN creation of member hosts.
+compute collections for automatic TN creation of member hosts."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_transport_node_profiles_facts.py
+++ b/library/nsxt_transport_node_profiles_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_node_profiles_facts
 short_description: List Transport Nodes Profiles
-description: Returns information about all transport node profiles.
+description: 
+  - Returns information about all transport node profiles.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_transport_nodes.py
+++ b/library/nsxt_transport_nodes.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_nodes
 short_description: Create a Transport Node
-description: Transport nodes are hypervisor hosts and NSX Edges that will participate
+description: "Transport nodes are hypervisor hosts and NSX Edges that will participate
               in an NSX-T overlay. For a hypervisor host, this means that it hosts
               VMs that will communicate over NSX-T logical switches. For NSX Edges,
               this means that it will have logical router uplinks and downlinks.
@@ -107,7 +107,7 @@ description: Transport nodes are hypervisor hosts and NSX Edges that will partic
               request.
 
               If host node (hypervisor) or edge node (router) is not already present in
-              system then information should be provided under node_deployment_info.
+              system then information should be provided under node_deployment_info."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi
@@ -176,7 +176,7 @@ options:
                     required: false
                     type: str
                 audit_username:
-                    description: "The default username is \"audit\". To configure username, you
+                    description: "The default username is 'audit'. To configure username, you
                                   must provide this property together with <b>audit_password</b>."
                     required: false
                     type: str
@@ -433,51 +433,51 @@ options:
         named_teaming_policy:
             description: The named teaming policy to be used by the remote tunnel endpoint
             required: False
-            type:'str'
+            type: 'str'
         rtep_vlan:
             description: VLAN id for remote tunnel endpoint
-            required:True
-            type:'dict'
+            required: True
+            type: 'dict'
             VlanID:
                 description: Virtual Local Area Network Identifier
-                required:False
-                type:'int'
+                required: False
+                type: 'int'
         ip_assignment_spec:
             description: Specification for IPs to be used with host switch remote tunnel endpoints
-            required:True
-            type:'dict'
+            required: True
+            type: 'dict'
             resource_type:
                 description: Resource type
-                required:True
-                type:'str'
+                required: True
+                type: 'str'
             ip_pool_id:
                 description: IP pool id
-                required:False
-                type:'str'
+                required: False
+                type: 'str'
             ip_list:
                 description: List of IPs for transport node host switch virtual tunnel endpoints
-                required:False
-                type:'list'
+                required: False
+                type: 'list'
             ip_mac_list:
                 description: List of IPs and MACs for transport node host switch virtual tunnel endpoints 
-                required:False
-                type:'list'
+                required: False
+                type: 'list'
             default_gateway:
                 description: Default gateway
-                required:False
-                type:'dict'
+                required: False
+                type: 'dict'
                 IPAddress:
                     description: IPv4 or IPv6 address
-                    required:False
-                    type:'str'
+                    required: False
+                    type: 'str'
             subnet_mask:
                 description: Subnet mask
-                required:False
-                type:'dict'
+                required: False
+                type: 'dict'
                 IPAddress:
                     description: IPv4 IPv6 address
-                    required:False
-                    type:'str'
+                    required: False
+                    type: 'str'
     tags: 
         description: Opaque identifiers meaningful to the API user
         required: False

--- a/library/nsxt_transport_nodes.py
+++ b/library/nsxt_transport_nodes.py
@@ -23,92 +23,89 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_nodes
 short_description: Create a Transport Node
-description: "Transport nodes are hypervisor hosts and NSX Edges that will participate
-              in an NSX-T overlay. For a hypervisor host, this means that it hosts
-              VMs that will communicate over NSX-T logical switches. For NSX Edges,
-              this means that it will have logical router uplinks and downlinks.
+description: 
+    - Transport nodes are hypervisor hosts and NSX Edges that will participate in an NSX-T overlay. 
+    - For a hypervisor host, this means that it hosts
+      VMs that will communicate over NSX-T logical switches. 
+    - For NSX Edges, this means that it will have logical router uplinks and downlinks.
 
-              This API creates transport node for a host node (hypervisor) or edge node
-              (router) in the transport network.
+    - This API creates transport node for a host node (hypervisor) or edge node
+      (router) in the transport network.
 
-              When you run this command for a host, NSX Manager attempts to install the
-              NSX kernel modules, which are packaged as VIB, RPM, or DEB files. For the
-              installation to succeed, you must provide the host login credentials and the
-              host thumbprint.
+    - When you run this command for a host, NSX Manager attempts to install the
+      NSX kernel modules, which are packaged as VIB, RPM, or DEB files. 
+    - For the installation to succeed, you must provide the host login credentials and the
+      host thumbprint.
 
-              To get the ESXi host thumbprint, SSH to the host and run the
-              <b>openssl x509 -in /etc/vmware/ssl/rui.crt -fingerprint -sha256 -noout</b>
-              command.
+    - "To get the ESXi host thumbprint, SSH to the host and run the
+      'openssl x509 -in /etc/vmware/ssl/rui.crt -fingerprint -sha256 -noout' command."
 
-              To generate host key thumbprint using SHA-256 algorithm please follow the
-              steps below.
+    - To generate host key thumbprint using SHA-256 algorithm please follow the
+      steps below.
 
-              Log into the host, making sure that the connection is not vulnerable to a
-              man in the middle attack. Check whether a public key already exists.
-              Host public key is generally located at '/etc/ssh/ssh_host_rsa_key.pub'.
-              If the key is not present then generate a new key by running the following
-              command and follow the instructions.
+    - "Log into the host, making sure that the connection is not vulnerable to a
+      man in the middle attack. Check whether a public key already exists.
+    - Host public key is generally located at '/etc/ssh/ssh_host_rsa_key.pub'."
+    - If the key is not present then generate a new key by running the following
+      command and follow the instructions.
+    - ssh-keygen -t rsa
 
-              <b>ssh-keygen -t rsa</b>
+    - Now generate a SHA256 hash of the key using the following command. 
+    - "Please make sure to pass the appropriate file name if the public key is stored with
+      a different file name other than the default 'id_rsa.pub'."
 
-              Now generate a SHA256 hash of the key using the following command. Please
-              make sure to pass the appropriate file name if the public key is stored with
-              a different file name other than the default 'id_rsa.pub'.
+    - "awk '{print $2}' id_rsa.pub | base64 -d | sha256sum -b | sed 's/ .*$//' | xxd -r -p | base64"
+    - This api is deprecated as part of FN+TN unification. 
+    - Please use Transport Node API to install NSX components on a node.
 
-              <b>awk '{print $2}' id_rsa.pub | base64 -d | sha256sum -b | sed 's/ .*$//' | xxd -r -p | base64</b>
-              This api is deprecated as part of FN+TN unification. Please use Transport Node API
-              to install NSX components on a node.
+    - Additional documentation on creating a transport node can be found
+      in the NSX-T Installation Guide.
 
-              Additional documentation on creating a transport node can be found
-              in the NSX-T Installation Guide.
+    - In order for the transport node to forward packets,
+      the host_switch_spec property must be specified.
 
-              In order for the transport node to forward packets,
-              the host_switch_spec property must be specified.
+    - Host switches (called bridges in OVS on KVM hypervisors) are the
+      individual switches within the host virtual switch. 
+    - Virtual machines are connected to the host switches.
 
-              Host switches (called bridges in OVS on KVM hypervisors) are the
-              individual switches within the host virtual switch. Virtual machines
-              are connected to the host switches.
+    - When creating a transport node, you need to specify if the host switches
+      are already manually preconfigured on the node, or if NSX should create
+      and manage the host switches. 
+    - You specify this choice by the type of host switches you pass in the host_switch_spec property of the
+      TransportNode request payload.
 
-              When creating a transport node, you need to specify if the host switches
-              are already manually preconfigured on the node, or if NSX should create
-              and manage the host switches. You specify this choice by the type
-              of host switches you pass in the host_switch_spec property of the
-              TransportNode request payload.
+    - For a KVM host, you can preconfigure the host switch, or you can have
+      NSX Manager perform the configuration. 
+    - For an ESXi host or NSX Edge node, NSX Manager always configures the host switch.
 
-              For a KVM host, you can preconfigure the host switch, or you can have
-              NSX Manager perform the configuration. For an ESXi host or NSX Edge
-              node, NSX Manager always configures the host switch.
+    - To preconfigure the host switches on a KVM host, pass an array
+      of PreconfiguredHostSwitchSpec objects that describes those host
+      switches. 
+    - In the current NSX-T release, only one prefonfigured host
+      switch can be specified.  
+    - See the PreconfiguredHostSwitchSpec schema definition for documentation on the properties that must be provided.
+    - Preconfigured host switches are only supported on KVM hosts, not on ESXi hosts or NSX Edge nodes.
 
-              To preconfigure the host switches on a KVM host, pass an array
-              of PreconfiguredHostSwitchSpec objects that describes those host
-              switches. In the current NSX-T release, only one prefonfigured host
-              switch can be specified.  See the PreconfiguredHostSwitchSpec schema
-              definition for documentation on the properties that must be provided.
-              Preconfigured host switches are only supported on KVM hosts, not on
-              ESXi hosts or NSX Edge nodes.
+    - To allow NSX to manage the host switch configuration on KVM hosts,
+      ESXi hosts, or NSX Edge nodes, pass an array of StandardHostSwitchSpec
+      objects in the host_switch_spec property, and NSX will automatically
+      create host switches with the properties you provide. 
+    - In the current NSX-T release, up to 5 host switches can be automatically managed.
+    - See the StandardHostSwitchSpec schema definition for documentation on
+      the properties that must be provided.
 
-              To allow NSX to manage the host switch configuration on KVM hosts,
-              ESXi hosts, or NSX Edge nodes, pass an array of StandardHostSwitchSpec
-              objects in the host_switch_spec property, and NSX will automatically
-              create host switches with the properties you provide. In the current
-              NSX-T release, up to 5 host switches can be automatically managed.
-              See the StandardHostSwitchSpec schema definition for documentation on
-              the properties that must be provided.
+    - "Note: previous versions of NSX-T used a property named host_switches
+      to specify the host switch configuration on the transport node."
+    - That property is deprecated, but still functions. 
+    - You should configure new host switches using the host_switch_spec property.
+    - The request should either provide node_deployement_info or node_id.
 
-              Note: previous versions of NSX-T used a property named host_switches
-              to specify the host switch configuration on the transport node. That
-              property is deprecated, but still functions. You should configure new
-              host switches using the host_switch_spec property.
+    - If the host node (hypervisor) or edge node (router) is already added in
+      system then it can be converted to transport node by providing node_id in
+      request.
 
-              The request should either provide node_deployement_info or node_id.
-
-              If the host node (hypervisor) or edge node (router) is already added in
-              system then it can be converted to transport node by providing node_id in
-              request.
-
-              If host node (hypervisor) or edge node (router) is not already present in
-              system then information should be provided under node_deployment_info."
-
+    - If host node (hypervisor) or edge node (router) is not already present in
+      system then information should be provided under node_deployment_info.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:

--- a/library/nsxt_transport_nodes_facts.py
+++ b/library/nsxt_transport_nodes_facts.py
@@ -23,13 +23,12 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_nodes_facts
 short_description: List Transport Nodes
-description: Returns information about all transport nodes along with underlying host or
-              edge details. A transport node is a host or edge that contains hostswitches.
-              A hostswitch can have virtual machines connected to them.
-
-              Because each transport node has hostswitches, transport nodes can also have
-              virtual tunnel endpoints, which means that they can be part of the overlay.
-
+description: 
+  - Returns information about all transport nodes along with underlying host or edge details. 
+  - A transport node is a host or edge that contains hostswitches.
+  - A hostswitch can have virtual machines connected to them.
+  - Because each transport node has hostswitches, transport nodes can also have
+    virtual tunnel endpoints, which means that they can be part of the overlay.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:

--- a/library/nsxt_transport_zones.py
+++ b/library/nsxt_transport_zones.py
@@ -23,9 +23,9 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_zones
 short_description: Create a Transport Zone
-description: Creates a new transport zone. The required parameters are host_switch_name
+description: "Creates a new transport zone. The required parameters are host_switch_name
 and transport_type (OVERLAY or VLAN). The optional parameters are
-description and display_name.
+description and display_name."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_transport_zones.py
+++ b/library/nsxt_transport_zones.py
@@ -23,10 +23,10 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_zones
 short_description: Create a Transport Zone
-description: "Creates a new transport zone. The required parameters are host_switch_name
-and transport_type (OVERLAY or VLAN). The optional parameters are
-description and display_name."
-
+description: 
+    - Creates a new transport zone. 
+    - The required parameters are host_switch_name and transport_type (OVERLAY or VLAN). 
+    - The optional parameters are description and display_name.
 version_added: "2.7"
 author: Rahul Raghuvanshi
 options:

--- a/library/nsxt_transport_zones_facts.py
+++ b/library/nsxt_transport_zones_facts.py
@@ -23,27 +23,29 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_zones_facts
 short_description: List Transport Zones
-description: Returns information about configured transport zones. NSX requires at
-              least one transport zone. NSX uses transport zones to provide connectivity
-              based on the topology of the underlying network, trust zones, or
-              organizational separations. For example, you might have hypervisors that
-              use one network for management traffic and a different network for VM
-              traffic. This architecture would require two transport zones. The
-              combination of transport zones plus transport connectors enables NSX to
-              form tunnels between hypervisors. Transport zones define which interfaces
-              on the hypervisors can communicate with which other interfaces on other
-              hypervisors to establish overlay tunnels or provide connectivity to a VLAN.
-              A logical switch can be in one (and only one) transport zone. This means
-              that all of a switch's interfaces must be in the same transport zone.
-              However, each hypervisor virtual switch (OVS or VDS) has multiple
-              interfaces (connectors), and each connector can be attached to a different
-              logical switch. For example, on a single hypervisor with two connectors,
-              connector A can be attached to logical switch 1 in transport zone A, while
-              connector B is attached to logical switch 2 in transport zone B. In this
-              way, a single hypervisor can participate in multiple transport zones. The
-              API for creating a transport zone requires that a single host switch be
-              specified for each transport zone, and multiple transport zones can share
-              the same host switch.
+description: 
+  - Returns information about configured transport zones. 
+  - NSX requires at least one transport zone. 
+  - NSX uses transport zones to provide connectivity based on the topology of the underlying network, trust zones, or
+    organizational separations. 
+  - For example, you might have hypervisors that use one network for management traffic and a different network for VM
+    traffic. This architecture would require two transport zones. The
+    combination of transport zones plus transport connectors enables NSX to
+    form tunnels between hypervisors. 
+  - Transport zones define which interfaces
+    on the hypervisors can communicate with which other interfaces on other
+    hypervisors to establish overlay tunnels or provide connectivity to a VLAN.
+    A logical switch can be in one (and only one) transport zone. 
+  - This means that all of a switch's interfaces must be in the same transport zone.
+    However, each hypervisor virtual switch (OVS or VDS) has multiple
+    interfaces (connectors), and each connector can be attached to a different
+    logical switch. For example, on a single hypervisor with two connectors,
+    connector A can be attached to logical switch 1 in transport zone A, while
+    connector B is attached to logical switch 2 in transport zone B. In this
+    way, a single hypervisor can participate in multiple transport zones. The
+    API for creating a transport zone requires that a single host switch be
+    specified for each transport zone, and multiple transport zones can share
+    the same host switch.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_upgrade_eula_accept.py
+++ b/library/nsxt_upgrade_eula_accept.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_eula_accept
 short_description: 'Accept end user license agreement'
-description: "Accept end user license agreement "
+description: 
+  - Accept end user license agreement.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_eula_accept_facts.py
+++ b/library/nsxt_upgrade_eula_accept_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_eula_accept_facts
 short_description: 'Gets EULA acceptance status and contents'
-description: "Returns EULA acceptance status and the contents."
+description: 
+  - Returns EULA acceptance status and the contents.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_groups.py
+++ b/library/nsxt_upgrade_groups.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_groups
 short_description: 'Create a group of upgrade units.'
-description: 'Create a group of upgrade units.'
+description: 
+  - Create a group of upgrade units.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_groups_facts.py
+++ b/library/nsxt_upgrade_groups_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_group_facts
 short_description: 'Get the upgrade groups information'
-description: 'Get the upgrade groups information'
+description: 
+  - Get the upgrade groups information.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_history.py
+++ b/library/nsxt_upgrade_history.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_history
 short_description: 'Get upgrade history'
-description: "Get upgrade history"
+description: 
+  - Get upgrade history.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_plan.py
+++ b/library/nsxt_upgrade_plan.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_plan
 short_description: 'Upgrade plan settings for the component'
-description: 'Upgrade plan settings for the component'
+description:
+  - Upgrade plan settings for the component.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_plan_facts.py
+++ b/library/nsxt_upgrade_plan_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_plan_facts
 short_description: 'Get the upgrade plan settings for the component.'
-description: "Get the upgrade plan settings for the component."
+description: 
+  - Get the upgrade plan settings for the component.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_postchecks.py
+++ b/library/nsxt_upgrade_postchecks.py
@@ -23,11 +23,11 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_postchecks
 short_description: 'Execute post-upgrade checks'
-description: "Run pre-defined checks to identify potential issues which can be 
-              encountered after an upgrade. The results
-              of the checks are added to the respective upgrade units aggregate-info. The 
-              progress and status of operation is part of upgrade status summary of 
-              individual components."
+description: 
+  - Run pre-defined checks to identify potential issues which can be encountered after an upgrade. 
+  - The results of the checks are added to the respective upgrade units aggregate-info. 
+  - The progress and status of operation is part of upgrade status summary of 
+    individual components.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_postchecks.py
+++ b/library/nsxt_upgrade_postchecks.py
@@ -48,7 +48,7 @@ options:
             - host
             - mp
             - edge
-        description: "Component type on which post upgrade is to be run.
+        description: "Component type on which post upgrade is to be run."
         required: true   
 '''
 

--- a/library/nsxt_upgrade_pre_post_checks_facts.py
+++ b/library/nsxt_upgrade_pre_post_checks_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_pre_post_checks_facts
 short_description: 'Get the pre and post upgrade checks'
-description: 'Get the pre and post upgrade checks'
+description:
+  - Get the pre and post upgrade checks.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_prechecks.py
+++ b/library/nsxt_upgrade_prechecks.py
@@ -23,11 +23,11 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_prechecks
 short_description: 'Execute pre-upgrade checks'
-description: "Run pre-defined checks to identify potential issues which can be 
-              encountered during an upgrade or can cause an upgrade to fail. The results 
-              of the checks are added to the respective upgrade units aggregate-info. The 
-              progress and status of operation is part of upgrade status summary of 
-              individual components."
+description: 
+  - Run pre-defined checks to identify potential issues which can be 
+    encountered during an upgrade or can cause an upgrade to fail. 
+  - The results of the checks are added to the respective upgrade units aggregate-info. 
+  - The progress and status of operation is part of upgrade status summary of individual components.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_run.py
+++ b/library/nsxt_upgrade_run.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_run
 short_description: 'Start the upgrade'
-description: 'Upgrade will start as per the upgrade plan.'
+description: 
+  - Upgrade will start as per the upgrade plan.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_status_summary_facts.py
+++ b/library/nsxt_upgrade_status_summary_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_status_summary_facts
 short_description: 'Get the upgrade groups information'
-description: 'Get the upgrade groups information'
+description: 
+  - Get the upgrade groups information.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_uc.py
+++ b/library/nsxt_upgrade_uc.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_uc
 short_description: 'Upgrade the upgrade coordinator'
-description: "Upgrade the upgrade coordinator"
+description: 
+  - Upgrade the upgrade coordinator.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_uc_facts.py
+++ b/library/nsxt_upgrade_uc_facts.py
@@ -23,8 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_uc_facts
 short_description: Get upgrade-coordinator upgrade status 
-description: Get upgrade-coordinator upgrade status 
-
+description: 
+  - Get upgrade-coordinator upgrade status.
 version_added: "2.7"
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_upload_mub.py
+++ b/library/nsxt_upgrade_upload_mub.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upgrade_upload_mub
 short_description: 'Uploads upgrade mub'
-description: "Uploads upgrade mub"
+description: 
+    - Uploads upgrade mub.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_upgrade_upload_mub_facts.py
+++ b/library/nsxt_upgrade_upload_mub_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_upload_upgrade_bundle_facts
 short_description: 'Get uploaded upgrade bundle information.'
-description: "Get uploaded upgrade bundle information."
+description: 
+  - Get uploaded upgrade bundle information.
 version_added: '2.7'
 author: 'Kommireddy Akhilesh'
 options:

--- a/library/nsxt_uplink_profiles.py
+++ b/library/nsxt_uplink_profiles.py
@@ -23,10 +23,11 @@ DOCUMENTATION = '''
 ---
 module: nsxt_uplink_profiles
 short_description: Create a Hostswitch Profile
-description: Creates a hostswitch profile. The resource_type is required. For uplink
-              profiles, the teaming and policy parameters are required. By default, the
-              mtu is 1600 and the transport_vlan is 0. The supported MTU range is 1280
-              through 9000.
+description: 
+    - Creates a hostswitch profile. The resource_type is required. 
+    - For uplink profiles, the teaming and policy parameters are required. 
+    - By default, the mtu is 1600 and the transport_vlan is 0. 
+    - The supported MTU range is 1280 through 9000.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_uplink_profiles_facts.py
+++ b/library/nsxt_uplink_profiles_facts.py
@@ -23,13 +23,15 @@ DOCUMENTATION = '''
 ---
 module: nsxt_uplink_profiles_facts
 short_description: List Hostswitch Profiles
-description: Returns information about the configured hostswitch profiles. Hostswitch
-              profiles define networking policies for hostswitches (sometimes referred to
-              as bridges in OVS). Currently, only uplink teaming is supported. Uplink
-              teaming allows NSX to load balance traffic across different physical NICs
-              (PNICs) on the hypervisor hosts. Multiple teaming policies are supported,
-              including LACP active, LACP passive, load balancing based on source ID, and
-              failover order.
+description: 
+  - Returns information about the configured hostswitch profiles. 
+  - Hostswitch profiles define networking policies for hostswitches (sometimes referred to
+    as bridges in OVS). 
+  - Currently, only uplink teaming is supported. 
+  - Uplink teaming allows NSX to load balance traffic across different physical NICs
+    (PNICs) on the hypervisor hosts. Multiple teaming policies are supported,
+    including LACP active, LACP passive, load balancing based on source ID, and
+    failover order.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_virtual_ip.py
+++ b/library/nsxt_virtual_ip.py
@@ -23,9 +23,10 @@ DOCUMENTATION = '''
 ---
 module: nsxt_virtual_ip
 short_description: 'Sets and clears cluster virtual IP address'
-description: "Sets the cluster virtual IP address. Note, all nodes in the management 
-              cluster must be in the same subnet. If not, a 409 CONFLICT status is 
-              returned. "
+description: 
+  - Sets the cluster virtual IP address. 
+  - Note, all nodes in the management cluster must be in the same subnet. 
+  - If not, a 409 CONFLICT status is returned.
 version_added: '2.7'
 author: 'Rahul Raghuvanshi'
 options:

--- a/library/nsxt_virtual_ip_facts.py
+++ b/library/nsxt_virtual_ip_facts.py
@@ -23,7 +23,8 @@ DOCUMENTATION = '''
 ---
 module: nsxt_vitual_ip_facts
 short_description: Read cluster virtual IP address
-description: Returns the configured cluster virtual IP address or null if not configured.
+description: 
+  - Returns the configured cluster virtual IP address or null if not configured.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_vm_tags.py
+++ b/library/nsxt_vm_tags.py
@@ -29,7 +29,7 @@ DOCUMENTATION = '''
 module: nsxt_vm_tags
 short_description: Update tags on NSXT VM
 description:
-    Update tags on NSXT VM
+    - Update tags on NSXT VM.
 version_added: "2.8"
 author: Gautam Verma
 options:


### PR DESCRIPTION
Some Modules could not be parse via the [`ansible-doc` command ](https://docs.ansible.com/ansible/latest/cli/ansible-doc.html).

These changes fix that issue.
Additionally, some long descriptions were refactored.

I know the changes seem like at lot, I went over als the modules to ensure the command works with each of them. If you need more atomic changes, please let me know.