### PR TITLE
Make docs parseable via ansible-doc

### DIFF
--- a/library/nsxt_certificates.py
+++ b/library/nsxt_certificates.py
@@ -44,13 +44,13 @@ options:
         required: true
         type: str
     display_name:
-        description:'Identifier to use when displaying entity in logs or GUI'
+        description: 'Identifier to use when displaying entity in logs or GUI'
         required: true
         type: str
     pem_encoded_file:
         description: 'File containing pem encoded certificate data'
         required: true
-        type='str' 
+        type: 'str' 
     private_key_file:
         description: 'File containing private key data'
         required: false

--- a/library/nsxt_compute_collection_fabric_templates.py
+++ b/library/nsxt_compute_collection_fabric_templates.py
@@ -52,7 +52,7 @@ options:
         required: false
         type: str
     compute_manager_name:
-        description: 'Cluster Manager's Name'
+        description: "Cluster Manager's Name"
         required: false
         type: str
     display_name:

--- a/library/nsxt_deploy_ova.py
+++ b/library/nsxt_deploy_ova.py
@@ -41,7 +41,7 @@ options:
         type: str
     ovftool_path:
         description: Path of ovf tool
-        type: 'str',
+        type: 'str'
     folder:
         description:  vCenter folder
         required: false

--- a/library/nsxt_fabric_nodes.py
+++ b/library/nsxt_fabric_nodes.py
@@ -33,7 +33,7 @@ description: Creates a host node (hypervisor) or edge node (router) in the trans
              host thumbprint.
 
              To get the ESXi host thumbprint, SSH to the host and run the
-             <b>openssl x509 -in /etc/vmware/ssl/rui.crt -fingerprint -sha256 -noout</b>
+             'openssl x509 -in /etc/vmware/ssl/rui.crt -fingerprint -sha256 -noout'
              command.
 
              To generate host key thumbprint using SHA-256 algorithm please follow the
@@ -96,8 +96,8 @@ options:
                 required: false
                 type: str
             audit_username:
-                description: "The default username is \"audit\". To configure username, you must 
-                              provide this property together with <b>audit_password</b>."
+                description: "The default username is 'audit'. To configure username, you must 
+                              provide this property together with 'audit_password'."
                 required: false
                 type: str
             cli_password:
@@ -112,7 +112,7 @@ options:
                 type: str
             cli_username:
                 description: "To configure username, you must provide this property together 
-                              with <b>cli_password</b>."
+                              with 'cli_password'."
                 required: false
                 type: str
             description: "Username and password settings for the node.

--- a/library/nsxt_logical_ports.py
+++ b/library/nsxt_logical_ports.py
@@ -23,14 +23,14 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_ports
 short_description: Create a Logical Port
-description: Creates a new logical switch port. The required parameters are the
+description: "Creates a new logical switch port. The required parameters are the
 associated logical_switch_id and admin_state (UP or DOWN). Optional
 parameters are the attachment and switching_profile_ids. If you don't
 specify switching_profile_ids, default switching profiles are assigned to
 the port. If you don't specify an attachment, the switch port remains
 empty. To configure an attachment, you must specify an id, and
 optionally you can specify an attachment_type (VIF or LOGICALROUTER).
-The attachment_type is VIF by default.
+The attachment_type is VIF by default."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_logical_router_ports.py
+++ b/library/nsxt_logical_router_ports.py
@@ -23,11 +23,11 @@ DOCUMENTATION = '''
 ---
 module: nsxt_logical_router_ports
 short_description: Create a Logical Router Port
-description: Creates a logical router port. The required parameters include resource_type
+description: "Creates a logical router port. The required parameters include resource_type
 (LogicalRouterUpLinkPort, LogicalRouterDownLinkPort, LogicalRouterLinkPort,
 LogicalRouterLoopbackPort, LogicalRouterCentralizedServicePort); and
 logical_router_id (the router to which each logical router port is assigned).
-The service_bindings parameter is optional.
+The service_bindings parameter is optional."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_policy_bfd_config.py
+++ b/library/nsxt_policy_bfd_config.py
@@ -28,12 +28,10 @@ DOCUMENTATION = '''
 ---
 module: nsxt_policy_bfd_config
 short_description: Create or Delete a Policy BFD Config
-description:
-    Creates or deletes a Policy BFD Config.
-    Required attributes include id and display_name.
+description: "Creates or deletes a Policy BFD Config.
+    Required attributes include id and display_name."
 version_added: "2.8"
 author: Gautam Verma
-extends_documentation_fragment: vmware_nsxt
 options:
     hostname:
         description: Deployed NSX manager hostname.

--- a/library/nsxt_policy_tier0.py
+++ b/library/nsxt_policy_tier0.py
@@ -974,7 +974,7 @@ options:
                                 required: False
                                 suboptions:
                                     address_family:
-                                        description:
+                                        description: Address Family
                                         type: str
                                         required: False
                                         choices:

--- a/library/nsxt_transport_node_collections.py
+++ b/library/nsxt_transport_node_collections.py
@@ -23,11 +23,11 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_node_collections
 short_description: Create transport node collection by attaching Transport Node Profile to cluster.
-description: When transport node collection is created the hosts which are part
+description: "When transport node collection is created the hosts which are part
 of compute collection will be prepared automatically i.e. NSX Manager
 attempts to install the NSX components on hosts. Transport nodes for these
 hosts are created using the configuration specified in transport node
-profile.
+profile."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_transport_node_profiles.py
+++ b/library/nsxt_transport_node_profiles.py
@@ -22,10 +22,10 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: nsxt_transport_node_profiles
-short_description: Create a Transport Node Profile
-description: Transport node profile captures the configuration needed to create
+short_description: "Create a Transport Node Profile"
+description: "Transport node profile captures the configuration needed to create
 a transport node. A transport node profile can be attached to
-compute collections for automatic TN creation of member hosts.
+compute collections for automatic TN creation of member hosts."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_transport_nodes.py
+++ b/library/nsxt_transport_nodes.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_nodes
 short_description: Create a Transport Node
-description: Transport nodes are hypervisor hosts and NSX Edges that will participate
+description: "Transport nodes are hypervisor hosts and NSX Edges that will participate
               in an NSX-T overlay. For a hypervisor host, this means that it hosts
               VMs that will communicate over NSX-T logical switches. For NSX Edges,
               this means that it will have logical router uplinks and downlinks.
@@ -107,7 +107,7 @@ description: Transport nodes are hypervisor hosts and NSX Edges that will partic
               request.
 
               If host node (hypervisor) or edge node (router) is not already present in
-              system then information should be provided under node_deployment_info.
+              system then information should be provided under node_deployment_info."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi
@@ -176,7 +176,7 @@ options:
                     required: false
                     type: str
                 audit_username:
-                    description: "The default username is \"audit\". To configure username, you
+                    description: "The default username is 'audit'. To configure username, you
                                   must provide this property together with <b>audit_password</b>."
                     required: false
                     type: str
@@ -433,51 +433,51 @@ options:
         named_teaming_policy:
             description: The named teaming policy to be used by the remote tunnel endpoint
             required: False
-            type:'str'
+            type: 'str'
         rtep_vlan:
             description: VLAN id for remote tunnel endpoint
-            required:True
-            type:'dict'
+            required: True
+            type: 'dict'
             VlanID:
                 description: Virtual Local Area Network Identifier
-                required:False
-                type:'int'
+                required: False
+                type: 'int'
         ip_assignment_spec:
             description: Specification for IPs to be used with host switch remote tunnel endpoints
-            required:True
-            type:'dict'
+            required: True
+            type: 'dict'
             resource_type:
                 description: Resource type
-                required:True
-                type:'str'
+                required: True
+                type: 'str'
             ip_pool_id:
                 description: IP pool id
-                required:False
-                type:'str'
+                required: False
+                type: 'str'
             ip_list:
                 description: List of IPs for transport node host switch virtual tunnel endpoints
-                required:False
-                type:'list'
+                required: False
+                type: 'list'
             ip_mac_list:
                 description: List of IPs and MACs for transport node host switch virtual tunnel endpoints 
-                required:False
-                type:'list'
+                required: False
+                type: 'list'
             default_gateway:
                 description: Default gateway
-                required:False
-                type:'dict'
+                required: False
+                type: 'dict'
                 IPAddress:
                     description: IPv4 or IPv6 address
-                    required:False
-                    type:'str'
+                    required: False
+                    type: 'str'
             subnet_mask:
                 description: Subnet mask
-                required:False
-                type:'dict'
+                required: False
+                type: 'dict'
                 IPAddress:
                     description: IPv4 IPv6 address
-                    required:False
-                    type:'str'
+                    required: False
+                    type: 'str'
     tags: 
         description: Opaque identifiers meaningful to the API user
         required: False

--- a/library/nsxt_transport_zones.py
+++ b/library/nsxt_transport_zones.py
@@ -23,9 +23,9 @@ DOCUMENTATION = '''
 ---
 module: nsxt_transport_zones
 short_description: Create a Transport Zone
-description: Creates a new transport zone. The required parameters are host_switch_name
+description: "Creates a new transport zone. The required parameters are host_switch_name
 and transport_type (OVERLAY or VLAN). The optional parameters are
-description and display_name.
+description and display_name."
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/library/nsxt_upgrade_postchecks.py
+++ b/library/nsxt_upgrade_postchecks.py
@@ -48,7 +48,7 @@ options:
             - host
             - mp
             - edge
-        description: "Component type on which post upgrade is to be run.
+        description: "Component type on which post upgrade is to be run."
         required: true   
 '''
 


### PR DESCRIPTION
* This commit fixes syntax problems in the modules' descriptions. Now, it is possible to view the the documenation via [ansible-doc](https://docs.ansible.com/ansible/latest/cli/ansible-doc.html)

Signed-off-by: Bastian Scherber <bastian.scherber@gmail.com>