### PR TITLE
Add modules for IP Sets, NS Groups, Services and Firewall Section 

### DIFF
--- a/answerfile_firewall.yml
+++ b/answerfile_firewall.yml
@@ -1,20 +1,20 @@
 nsxt_ip_sets:
-- display_name: 'ips_test'
+- display_name: 'ips-fw-testing'
   ip_addresses:
   - '192.168.0.0/24'
   - '192.168.1.1'
   state: present
 
 nsxt_ns_groups:
-- display_name: 'ns_test'
+- display_name: 'ns-fw-testing'
   members:
     - resource_type: NSGroupSimpleExpression
       target_property: id
       op: EQUALS
       target_type: IPSet
-      value: 'ips_test'
+      value: 'ips-fw-testing'
   state: present
-- display_name: 'ns_test_criteria'
+- display_name: 'ns-fw-testing_criteria'
   membership_criteria:
     - resource_type: NSGroupTagExpression
       target_type: 'LogicalSwitch'
@@ -32,34 +32,34 @@ nsxt_ns_groups:
           tag: 'T1'
   state: present
 
-  nsxt_dfw_section_with_rules:
+nsxt_dfw_section_with_rules:
 - display_name: Test Section DFW
-  description: Testinging
+  description: Testing
   modify_placement: True
   stateful: True
   state: present
   applied_tos:
-  - target_display_name: 'ns_Dynamic1'
+  - target_display_name: 'ns-fw-testing'
     target_type: NSGroup
-  - target_display_name: 'test_lp'
+  - target_display_name: 'lp-fw-testing'
     target_type: LogicalPort
-  - target_display_name: 'PKS_Infra'
+  - target_display_name: 'ls-fw-testing'
     target_type: LogicalSwitch
   section_placement:
-    operation: insert_after
-    display_name: top_section
+    operation: insert_before
+    display_name: "Default Layer3 Section"
   rules:
   - display_name: 'Test Rule DFW'
     description: Testing
     action: ALLOW
     applied_tos:
-    - target_display_name: 'logical_switch_test'
+    - target_display_name: 'ls-fw-testing'
       target_type: LogicalSwitch
     context_profiles:
     - target_display_name: 'ACTIVDIR'
       target_type: NSProfile
     destinations:
-    - target_display_name: 'ip_set_test' # Will insert target_id a runtime
+    - target_display_name: 'ips-fw-testing' # Will insert target_id a runtime
       target_type: IPSet
     direction: IN_OUT
     disabled: False
@@ -72,7 +72,7 @@ nsxt_ns_groups:
     - target_display_name: 'Active Directory Server UDP' # Will insert target_id a runtime
       target_type: NSService
     sources: 
-    - target_display_name: 'ns_group_test'# Will insert target_id a runtime
+    - target_display_name: 'ns-fw-testing' # Will insert target_id a runtime
       target_type: NSGroup
 
 - display_name: Test Section Edge
@@ -84,7 +84,7 @@ nsxt_ns_groups:
   - scope: 'test scope'
     tag: 'test tag'
   applied_tos:
-  - target_display_name: 'tier-0'
+  - target_display_name: 't1-fw-testing'
     target_type: LogicalRouter
   section_placement:
     operation: insert_bottom
@@ -93,10 +93,10 @@ nsxt_ns_groups:
     description: Testing
     action: ALLOW
     applied_tos:
-    - target_display_name: 'Uplink'
+    - target_display_name: 'lrp-fw-testing'
       target_type: LogicalRouterPort
     destinations: 
-    - target_display_name: 'ip_set_test'
+    - target_display_name: 'ips-fw-testing'
       target_type: IPSet
     direction: IN_OUT
     disabled: False
@@ -104,7 +104,7 @@ nsxt_ns_groups:
     logged: True
     resource_type: FirewallRule
     services: 
-    - target_display_name: 'SSL' # Will insert target_id a runtime
+    - target_display_name: 'SSH' # Will insert target_id a runtime
       target_type: NSService
     sources: 
     - target_display_name: '10.1.1.1'

--- a/answerfile_firewall.yml
+++ b/answerfile_firewall.yml
@@ -1,0 +1,124 @@
+nsxt_ip_sets:
+- display_name: 'ips_test'
+  ip_addresses:
+  - '192.168.0.0/24'
+  - '192.168.1.1'
+  state: present
+
+nsxt_ns_groups:
+- display_name: 'ns_test'
+  members:
+    - resource_type: NSGroupSimpleExpression
+      target_property: id
+      op: EQUALS
+      target_type: IPSet
+      value: 'ips_test'
+  state: present
+- display_name: 'ns_test_criteria'
+  membership_criteria:
+    - resource_type: NSGroupTagExpression
+      target_type: 'LogicalSwitch'
+      scope: 'S1'
+      tag: 'T1'
+    - resource_type: NSGroupComplexExpression
+      expressions:
+        - resource_type: NSGroupTagExpression
+          target_type: 'LogicalPort'
+          scope: 'S2'
+          tag: 'T2'
+        - resource_type: NSGroupTagExpression
+          target_type: 'LogicalPort'
+          scope: '99'
+          tag: 'T1'
+  state: present
+
+  nsxt_dfw_section_with_rules:
+- display_name: Test Section DFW
+  description: Testinging
+  modify_placement: True
+  stateful: True
+  state: present
+  applied_tos:
+  - target_display_name: 'ns_Dynamic1'
+    target_type: NSGroup
+  - target_display_name: 'test_lp'
+    target_type: LogicalPort
+  - target_display_name: 'PKS_Infra'
+    target_type: LogicalSwitch
+  section_placement:
+    operation: insert_after
+    display_name: top_section
+  rules:
+  - display_name: 'Test Rule DFW'
+    description: Testing
+    action: ALLOW
+    applied_tos:
+    - target_display_name: 'logical_switch_test'
+      target_type: LogicalSwitch
+    context_profiles:
+    - target_display_name: 'ACTIVDIR'
+      target_type: NSProfile
+    destinations:
+    - target_display_name: 'ip_set_test' # Will insert target_id a runtime
+      target_type: IPSet
+    direction: IN_OUT
+    disabled: False
+    ip_protocol: IPV4_IPV6
+    logged: True
+    notes: 'Test rule to prove FW rules'
+    resource_type: FirewallRule
+    rule_tag: Test-Log-Tag
+    services: 
+    - target_display_name: 'Active Directory Server UDP' # Will insert target_id a runtime
+      target_type: NSService
+    sources: 
+    - target_display_name: 'ns_group_test'# Will insert target_id a runtime
+      target_type: NSGroup
+
+- display_name: Test Section Edge
+  description: Testing edge1
+  modify_placement: False
+  stateful: True
+  state: present
+  tags:
+  - scope: 'test scope'
+    tag: 'test tag'
+  applied_tos:
+  - target_display_name: 'tier-0'
+    target_type: LogicalRouter
+  section_placement:
+    operation: insert_bottom
+  rules:
+  - display_name: 'Test Rule Edge'
+    description: Testing
+    action: ALLOW
+    applied_tos:
+    - target_display_name: 'Uplink'
+      target_type: LogicalRouterPort
+    destinations: 
+    - target_display_name: 'ip_set_test'
+      target_type: IPSet
+    direction: IN_OUT
+    disabled: False
+    ip_protocol: IPV4
+    logged: True
+    resource_type: FirewallRule
+    services: 
+    - target_display_name: 'SSL' # Will insert target_id a runtime
+      target_type: NSService
+    sources: 
+    - target_display_name: '10.1.1.1'
+      target_type: IPAddress
+
+
+services:
+- display_name: 'HTTPS-ALT'
+  description: random
+  nsservice_element:
+    destination_ports:
+    - '8443'
+    l4_protocol: TCP
+    resource_type: L4PortSetNSService
+  tags:
+  - scope: 'test scope'
+    tag: 'test tag'

--- a/library/nsxt_firewall_section_with_rules.py
+++ b/library/nsxt_firewall_section_with_rules.py
@@ -1,0 +1,918 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 VMware, Inc.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: nsxt_dfw_sections
+short_description: Module to insert and modify firewall sections with or without rules.
+description:  'Creates Firewall Sections, with the option to add rules.
+              This is intended for use with GitOps workflows, where the configuration is stored in Git and the
+              playbook run after a change has been made.
+              Large firewall sections with many hundreds of rules can cause issues with API performance and the
+              API guide states supported rule section size and maximum levels of concurrency.
+              If section params or any rule params are changed, it will re-apply the configuration passed to Ansible
+              in a single API call per section  with all firewall rules.
+
+              Usage:
+                - Firewall rule names must be unique in each section, as the name is used to compare existing rules
+                  against vars being passed in.
+                - Sections managed by Ansible must have unique display names.
+
+              Reference the API guide for which params can be used with which operations.
+              Maximums and descriptions below taken from the 2.4 API guide, consult for changes.'
+
+version_added: "2.7"
+author: Matt Proud
+options:
+    display_name:
+        description: Display name
+        required: true
+        type: str
+    hostname:
+        description: Deployed NSX manager hostname.
+        required: true
+        type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+    applied_tos:
+        description: 'List of obects section applies. Must conform to ResourceReference schema.
+                      For distrubuted firewall rules target_type must be:
+                        ['NSGroup', 'LogicalSwitch', 'LogicalPort']
+                        Max 128 supported objects
+                      For edge firewall rules target_type must be:
+                        ['LogicalRouter']
+                        Cannot mix distribted and edge types. Section can only apply to a single logical router'
+        required: False
+        type: list
+        target_display_name:
+            description: Display name of the NSX resource.
+            required: True
+            type: str
+        target_type: 
+            choices: ['NSGroup', 'LogicalSwitch', 'LogicalPort', 'LogicalRouter']
+            description: Type of the NSX resource.
+            required: True
+            type: str
+    description:
+        description: Description of this resource.
+        required: False
+        type: str
+    modify_placement:
+        default: False
+        description: When updating rules, flag will move section to desired placement.
+        required: False
+        type: bool
+    rules:
+        description: List of rules to be applied with the section. Rules follow FirewallRule schema.
+        required: True
+        type: list
+        display_name:
+            description: Display name
+            required: true
+            type: str
+        description:
+            description: Description of rule
+            required: False
+            type: str
+        action:
+            choices: ['ALLOW', 'DROP', 'REJECT', 'REDIRECT', 'DO_NOT_REDIRECT']
+            description: 'Action enforced on the packets which matches the distributed service rule. Currently DS Layer
+                          supports below actions. ALLOW - Forward any packet when a rule with this action gets a match
+                          (Used by Firewall). DROP - Drop any packet when a rule with this action gets a match. Packets
+                          won't go further(Used by Firewall). REJECT - Terminate TCP connection by sending TCP reset 
+                          for a packet when a rule with this action gets a match (Used by Firewall). REDIRECT - 
+                          Redirect any packet to a partner appliance when a rule with this action gets a match 
+                          (Used by Service Insertion). DO_NOT_REDIRECT - Do not redirect any packet to a partner 
+                          appliance when a rule with this action gets a match (Used by Service Insertion).'
+            required: True
+            type str
+        applied_tos:
+            description: List of obects rule applies. Must conform to ResourceReference schema.  Max 128.
+            required: False
+            type: list
+            target_display_name:
+                description: Display name of the NSX resource.
+                required: True
+                type: str
+            target_type: 
+                choices: ['NSGroup', 'LogicalSwitch', 'LogicalPort', 'LogicalRouterPort']
+                description: 'Type of the NSX resource. LogicalRouterPort only supported on Logical Router sections'
+                required: True
+                type: str
+        context_profiles:
+            description: 'List of conext profile objects applied. Must conform to ResourceReference schema. 
+                          Can only be usd for distrubted firewall sections on NSX-T 2.4. 
+                          Not supported on the Edge firewall. Max 128.'
+            required: False
+            type: list
+            target_display_name:
+                description: Display name of the NSX resource.
+                required: True
+                type: str
+            target_type: 
+                choices: ['NSProfile']
+                description: Type of the NSX resource.
+                required: True
+                type: str
+        destinations:
+            description: List of destination obects rule applies. Must conform to ResourceReference schema. Max 128.
+            required: False
+            type: list
+            target_display_name:
+                description: Display name of the NSX resource.
+                required: True
+                type: str
+            target_type: 
+                choices: ['IPSet', 'NSGroup', 'LogicalSwitch', 'LogicalPort']
+                description: Type of the NSX resource.
+                required: True
+                type: str
+        direction:
+            description: 'Rule direction in case of stateless distributed service rules. This will only considered if
+                          section level parameter is set to stateless. Default to IN_OUT if not specified.'
+            required: False
+            type: str
+        disabled:
+            description: Flag to disable rule. Disabled will only be persisted but never provisioned/realized.
+            required: False
+            type: bool
+        ip_protocol:
+            choices: ['IPV4', 'IPV6', 'IPV4_IPV6']
+            description: Type of IP packet that should be matched while enforcing the rule.
+            required: False
+            type: str
+        logged:
+            description: Flag to enable packet logging. Default is disabled.
+            required: False
+            type: bool
+        notes:
+            description: User notes specific to the rule. Max 2048 chars.
+            required: False
+            type: str
+        resouce_type:
+            choices: ['FirewallRule']
+            description: Type of NSX Resource.
+            required: False
+            type: str
+        rule_tag:
+            description: User level field which will be printed in CLI and packet logs. Max 32 chars.
+            required: False
+            type: str
+        services:
+            description: 'List of service obects rule applies. Must conform to ResourceReference schema.
+                          Each service should either comprise target_display_name and target_type, or service.
+                          Max 128.'
+            required: False
+            type: list
+            service:
+                description: 'List of custom services. Must conform to ResourceReference schema.
+                              Should either comprise target_display_name and target_type, or service.
+                              Custom services should conform to ALGTypeNSService, ICMPTypeNSService, 
+                              IGMPTypeNSService, IPProtocolNSService or L4PortSetNSService schemas.'
+                required: False
+                type: list
+                alg:
+                    choices: ['ORACLE_TNS', 'FTP', 'SUN_RPC_TCP', 'SUN_RPC_UDP', 'MS_RPC_TCP', 'MS_RPC_UDP', 
+                              'NBNS_BROADCAST', 'NBDG_BROADCAST', 'TFTP']
+                    description: 'The Application Layer Gateway (ALG) protocol. Consult the documentation for edge
+                                  rules as not all protocols are supported on edge firewalls.' 
+                    required: False
+                    type: str 
+                destination_ports:
+                    description: List of ports as integers. Max 15
+                    required: False
+                    type: list
+                icmp_code:
+                    description: ICMP message code
+                    required: False
+                    type: int
+                icmp_type:
+                    description: ICMP message type
+                    required: False
+                    type: int
+                l4_protocol:
+                protocol:
+                    choices: ['ICMPv4', 'ICMPv6']
+                    description: ICMP protocol type
+                    required: False
+                    type: list
+                protocol_number:
+                    description: The IP protocol number
+                    required: False
+                    type: int
+                resource_type:
+                    choices: ['ALGTypeNSService', 'IPProtocolNSService', 'L4PortSetNSService', 'ICMPTypeNSService',
+                              'IGMPTypeNSService']
+                    description: Type of service.
+                    required: False
+                    type: list
+                source_ports:
+                    description: List of ports as integers. Max 15
+                    required: False
+                    type: list
+            target_display_name:
+                description: Display name of the NSX resource.
+                required: False
+                type: str
+            target_type: 
+                choices: ['IPSet', 'NSGroup', 'LogicalSwitch', 'LogicalPort']
+                description: Type of the NSX resource.
+                required: False
+                type: str
+        sources:
+            description: List of source obects rule applies. Must conform to ResourceReference schema. Max 128.
+            required: False
+            type: list
+            target_display_name:
+                description: Display name of the NSX resource.
+                required: True
+                type: str
+            target_type: 
+                choices: ['NSService', 'NSServiceGroup']
+                description: 'Type of the NSX resource.'
+                required: True
+                type: str
+    resource_type:
+        choices: ['FirewallSectionRuleList']
+        description: Type of the NSX resource.
+        required: False
+        type: str
+    section_placement:
+        description: Options on where to insert new secton. This must be a reference to a section in the
+                     appropriate firewall.
+        required: False
+        type: dict
+        id:
+            description: Unique ID of the section to be paired with if insert_after or insert_before used.
+            required: false
+            type: str
+        display_name:
+            description: 'Display name of partner section if insert_after or insert_before used. Ignored if 
+                          id is used.'
+            required: false
+            type: str
+        operation:
+            choices: ['insert_top', 'insert_bottom', 'insert_after', 'insert_before']
+            description: 'Insert operation to place within the relevant firewall. In NSX-T 2.4.0, insert_bottom on 
+                          Logical Routers will insert below the default ruleset so should be avoided. Instead use
+                          insert_before and the ID of the default section of that router'
+            required: True
+            type: str
+    section_type:
+        choices: ['LAYER3']
+        description: Insert operation command
+        required: False
+        type: str
+    state:
+        choices: ['present', 'absent']
+        description: 'State can be either 'present' or 'absent'. 
+                      'present' is used to create or update resource. 
+                      'absent' is used to delete resource.'
+        required: true
+    stateful:
+        description: 'Stateful nature of the distributed service rules in the section.
+                     Stateful or Stateless nature of distributed service section is enforced 
+                     on all rules inside the section.' 
+        required: True
+        type: bool
+    tags:
+        description: 'Opaque identifiers meaningful to the API user. Max 30 items'
+        required: false
+        type: list
+        scope:
+            description: 'Tag scope. Tag searches may optionally be restricted by scope. Max len 128 charactors.'
+            required: true
+            type: str
+        tag:
+            description: ' 	Tag value. Identifier meaningful to user. Max len 128 charactors.'
+            required: true
+            type: str
+
+'''
+
+EXAMPLES = '''
+- name: Add Distributed Firewall Section with Rules
+  nsxt_dfw_section:
+    hostname: "10.192.167.137"
+    username: "admin"
+    password: "Admin!23Admin"
+    validate_certs: False
+    display_name: Test Section
+    description: Testing DFW
+    stateful: True
+    state: present
+    applied_tos:
+    section_placement:
+        operation: insert_top
+    rules:
+    - display_name: 'Test Rule'
+        description: Testing
+        action: ALLOW
+        applied_tos:
+        - target_display_name: 'ns_test'
+          target_type: NSGroup
+        context_profiles:
+        - target_display_name: 'SSL'
+          target_type: NSProfile
+        destinations: 
+        - target_display_name: 'ip_set_test'
+          target_type: IPSet
+        direction: IN_OUT
+        ip_protocol: IPV4
+        logged: True
+        resource_type: FirewallRule
+        rule_tag: Test-Log-Tag
+        services: 
+        - target_display_name: 'HTTPS'
+          target_type: NSService
+        sources: 
+        - target_display_name: '10.1.1.1'
+          target_type: IPAddress
+
+- name: Add Edge Firewall Section with Rules
+  nsxt_dfw_section:
+    hostname: "10.192.167.137"
+    username: "admin"
+    password: "Admin!23Admin"
+    validate_certs: False
+    display_name: Test Section
+    description: Testing Edge
+    stateful: True
+    state: present
+    applied_tos:
+    - target_display_name: 't0-router'
+        target_type: LogicalRouter
+    section_placement:
+        operation: insert_top
+    rules:
+    - display_name: 'Test Rule'
+        description: Testing
+        action: ALLOW
+        destinations: 
+        - target_display_name: 'ip_set_test'
+          target_type: IPSet
+        resource_type: FirewallRule
+        services: 
+        - target_display_name: 'HTTPS'
+          target_type: NSService
+        sources: 
+        - target_display_name: '10.1.1.1'
+          target_type: IPAddress
+
+- name: Add Distributed Firewall Section
+  nsxt_dfw_section:
+    hostname: "10.192.167.137"
+    username: "admin"
+    password: "Admin!23Admin"
+    validate_certs: False
+    display_name: Test Section
+    description: Testing edge
+    stateful: True
+    state: present
+'''
+
+RETURN = '''# '''
+
+import json, time, copy
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request
+from ansible.module_utils._text import to_native
+from collections import Counter
+
+
+ENDPOINT_LOOKUP = {'NSGroup': '/ns-groups', 'IPSet': '/ip-sets', 'FirewallSection': '/firewall/sections',
+                    'LogicalSwitch': '/logical-switches', 'LogicalPort': '/logical-ports', 'LogicalRouter': '/logical-routers', 
+                    'LogicalRouterPort': '/logical-router-ports', 'NSProfile': '/ns-profiles', 
+                    'NSServiceGroup': '/ns-service-groups', 'NSService': '/ns-services'}
+
+
+def get_all_request(module, manager_url, mgr_username, mgr_password, validate_certs, endpoint):
+    '''Handle the API service respondign with a cursor and make subsequent request.'''
+    try:
+        output_list = []
+        cursor = ''
+        while True:
+            (rc, resp) = request(manager_url + endpoint + cursor, headers=dict(Accept='application/json'),
+                        url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+            if resp['results']:
+                output_list += resp['results']
+            if resp.__contains__('cursor'):
+                cursor = '?cursor=' + resp['cursor']
+            else:
+                break
+        return output_list
+    except Exception as err:
+        module.fail_json(msg='Error accessing endpoint %s. \nError [%s]' % (endpoint, to_native(err)))
+
+def get_dfw_section_params(args=None):
+    args_to_remove = ['state', 'username', 'password', 'port', 'hostname', 'validate_certs']
+    for key in args_to_remove:
+        args.pop(key, None)
+    for key, value in args.copy().items():
+        if value == None:
+            args.pop(key, None)
+    return args
+
+def get_dfw_section_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, display_name):
+    '''Return dict of firewall section by section name, if name is unique'''
+    dfw_sections = get_all_request(module, manager_url, mgr_username, mgr_password, validate_certs, '/firewall/sections')
+    return_section = None
+    for dfw_section in dfw_sections:
+        if dfw_section.__contains__('display_name') and dfw_section['display_name'] == display_name:
+            if not return_section: # Handle there being 2 sections created with the same display name
+                return_section = dfw_section
+            else:
+                module.fail_json(msg='Section with display name %s exists more than once.' % (display_name))
+    return return_section
+
+# Generate IDs for each sub-section
+def update_param_list_with_ids(module, params, existing_config_lookup, duplicated_objects, rule_display_name, section_name):
+    '''Update sections with ID of objects based on display_name'''
+    for idx, param in enumerate(params):
+        try:
+            if param.__contains__('target_type') and param['target_display_name'] not in duplicated_objects[param['target_type']]:
+                if param['target_type'] == 'IPAddress':
+                    params[idx]['target_id'] = param['target_display_name']
+                else:
+                    params[idx]['target_id'] = existing_config_lookup[param['target_type']][param['target_display_name']]
+            elif param.__contains__('target_display_name') and param['target_display_name'] in duplicated_objects[param['target_type']]:
+                module.fail_json(msg='Object [%s] specified exists more than once with the same display name.' % (param['target_display_name']))
+        except KeyError as err:
+                module.fail_json(msg='Unable to find mandatory param [%s] within [%s] sub-section [%s]' % (to_native(err), rule_display_name, section_name))
+
+def update_rules_list_with_ids(module, rules, existing_config_lookup, list_section_names, duplicated_objects):
+    '''Loop through each rule and insert IDs into each section where display_name is supplied'''
+    for idx, rule in enumerate(rules):
+        for section_name in list_section_names:
+            if rule.__contains__(section_name) and rule[section_name]:
+                # Passing in the original rules list, so that it can be updated in place.
+                update_param_list_with_ids(module, rules[idx][section_name], existing_config_lookup, duplicated_objects,
+                                         'Rule ' + rule['display_name'], section_name)
+
+def insert_lists_if_missing(source_dict, keys):
+  '''Insert empty list as value in a dict if the dict does not contain the key'''
+  for key in keys:
+    if not source_dict.__contains__(key):
+      source_dict[key] = []
+
+def extract_services_list_of_strings(services):
+    '''Extract services and represent them as a list of sorted strings to allow comparison'''
+    output_list = []
+    for service in services:
+        item_string = ''
+        for key, value in service.items():
+            if isinstance(value, list):
+                for item in value:
+                    item_string += key + str(item)
+            else:
+                item_string += key + str(value)
+        
+        # String is sorted to allow for dictionary order to change.
+        output_list.append(''.join(sorted(item_string)))
+    return output_list
+
+def compare_custom_services(module, existing_services, new_services):
+    '''Compare custom services by extracting parameters as strings'''
+    if existing_services and new_services:
+        # Lists must be deep copied otherwise pop removes globally.
+        existing_services_copy = copy.deepcopy(existing_services)
+        new_services_copy = copy.deepcopy(new_services)
+        existing_custom_services = [d.pop('service') for d in existing_services_copy if 'service' in d]
+        new_custom_services = [d.pop('service') for d in new_services_copy if 'service' in d]
+        
+        if len(existing_custom_services) != len(new_custom_services):
+            return True
+        
+        elif existing_custom_services or new_custom_services:
+            # Extract list containing a strings of custom services. Lists of strings are hashable and faster to compare.
+            existing_custom_service_list = extract_services_list_of_strings(existing_custom_services)
+            new_custom_service_list = extract_services_list_of_strings(new_custom_services)
+            if not Counter(existing_custom_service_list) == Counter(new_custom_service_list):
+                return True
+
+    return False
+
+def convert_tag_dict_to_string(tag_list):
+    '''Convert list of tag dicts to a list of strings'''
+    existing_tag_strings = []
+    for tag in tag_list:
+        tag_string = ''
+        for key in ['tag', 'scope']:
+            if tag.__contains__(key) and tag[key] != '':
+                tag_string += key + tag[key]
+        existing_tag_strings.append(tag_string)
+    return existing_tag_strings
+
+def compare_tags(module, existing_tags, new_tags):
+    '''Compare tags as lists of strings to check for differences'''
+    if len(existing_tags) != len(new_tags):
+        return True
+    
+    # Convert tag dictionaries to strings to allow list compare and account of empty values in either element.
+    existing_tag_strings = convert_tag_dict_to_string(existing_tags)
+    new_tag_string = convert_tag_dict_to_string(new_tags)
+    if existing_tag_strings != new_tag_string:
+        return True
+        
+    return False
+
+def check_for_update(module, manager_url, mgr_username, mgr_password, validate_certs, dfw_section_params):
+    '''Check if any element of a section has changed'''
+    existing_dfw_section = get_dfw_section_from_display_name(module, manager_url, mgr_username, mgr_password, 
+                                                            validate_certs, dfw_section_params['display_name'])
+    if not existing_dfw_section:
+        return False
+    
+    # Lists must be deep copied otherwise pop removes globally.
+    copy_dfw_section_params = copy.deepcopy(dfw_section_params)
+    new_dfw_secton_rules = copy_dfw_section_params.pop('rules', [])
+    new_dfw_secton_applied_tos = copy_dfw_section_params.pop('applied_tos', [])
+    copy_dfw_section_params.pop('resource_type', None)
+    copy_tags = copy_dfw_section_params.pop('tags', [])
+    existing_tags = existing_dfw_section.pop('tags', [])
+    
+    # Check to ensure that all keys and values in the new params match the existing configuration.
+    if not all(k in existing_dfw_section and copy_dfw_section_params[k] == existing_dfw_section[k] for k in copy_dfw_section_params):
+        return True
+    
+    # Compare list of tags as strings
+    if compare_tags(module, existing_tags, copy_tags):
+        return True
+
+    # Check that applied_tos sections match.
+    insert_lists_if_missing(existing_dfw_section, ['applied_tos'])
+    existing_applied_tos = [d['target_type'] + d['target_id'] for d in existing_dfw_section['applied_tos'] if 'target_id' in d]
+    new_applied_tos = [d['target_type'] + d['target_id'] for d in dfw_section_params['applied_tos'] if 'target_id' in d]
+    if not Counter(existing_applied_tos) == Counter(new_applied_tos):
+        return True 
+    
+    # Create lookup table of existing rules by display name. Ignore duplicate names as would trigger a change anyway.
+    existing_rule_dict = {}
+    existing_dfw_section_rules = get_all_request(module, manager_url, mgr_username, mgr_password, validate_certs,
+                                                 '/firewall/sections/%s/rules' % existing_dfw_section['id'])
+    if len(existing_dfw_section_rules) != len(new_dfw_secton_rules):
+        return True
+    for rule in existing_dfw_section_rules:
+        try:
+            existing_rule_dict[rule['display_name']] = rule
+        except KeyError:
+            pass
+
+    # Iterate through each rule and compare each subsection list and finally the keys and values.
+    for new_rule in new_dfw_secton_rules:
+        try:
+            exsting_rule = existing_rule_dict[new_rule['display_name']]
+        except KeyError:
+            continue
+        section_labels = ['applied_tos', 'context_profiles', 'destinations', 'services', 'sources']
+        insert_lists_if_missing(new_rule, section_labels)
+        insert_lists_if_missing(existing_rule, section_labels)
+        for section in section_labels:
+            # Custom services don't have the target_id key, so need to be treated separately
+            if section == 'services':
+                if compare_custom_services(module, existing_rule[section], new_rule[section]):
+                    return True
+            existing_section_ids = [d['target_type'] + d['target_id'] for d in existing_rule[section] if 'target_id' in d]
+            new_section_ids = [d['target_type'] + d['target_id'] for d in new_rule[section] if 'target_id' in d]
+            if not Counter(existing_section_ids) == Counter(new_section_ids):
+                return True
+
+        # Remove lists for rules, so that the keys and values can be compared.
+        [new_rule.pop(key, None) for key in section_labels]
+        [existing_rule.pop(key, None) for key in section_labels]
+
+        if not all(k in existing_rule and new_rule[k] == existing_rule[k] for k in new_rule):
+            return True
+    return False
+
+def collect_all_existing_config(module, manager_url, mgr_username, mgr_password, validate_certs):
+    '''Collect all existing configuration and return as dict mapping display_name to IDs and list of duplicates'''
+    existing_config_lookup = {}
+    duplicated_objects = {'IPAddress': []} # Manually isert IP Addresses as the cannot be duplicated.
+    for endpoint_name, endpoint in ENDPOINT_LOOKUP.items():
+        resp = get_all_request(module, manager_url, mgr_username, mgr_password, validate_certs, endpoint)
+        if resp:
+            duplicated_objects[endpoint_name] = []
+            lookup_table = {}
+            for item in resp:
+                if item.__contains__('display_name') and item.__contains__('id'):
+                    if item['display_name'] not in duplicated_objects[endpoint_name]:
+                        lookup_table[item['display_name']] = item['id']
+                    else:
+                        duplicated_objects[endpoint_name].append(item['display_name'])
+            existing_config_lookup[endpoint_name] = lookup_table
+    return existing_config_lookup, duplicated_objects
+
+def add_backwards_compatibilty(module, manager_url, mgr_username, mgr_password, validate_certs, dfw_section_params):
+    '''Remove context profiles to allow support for 2.3 and below'''
+    try:
+        (rc, resp) = request(manager_url+ '/upgrade/summary', headers=dict(Accept='application/json'),
+                        url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+        if float(resp['system_version'][0:3]) < 2.4:
+            for idx, rule in enumerate(dfw_section_params['rules']):
+                dfw_section_params['rules'][idx].pop('context_profiles', None)
+                ENDPOINT_LOOKUP.pop('NSProfile', None)
+    except Exception as err:
+        module.fail_json(msg='Error accessing API verion details. Error [%s]' % (to_native(err)))
+
+def check_if_section_moved(module, manager_url, mgr_username, mgr_password, validate_certs, section_placement, 
+                           existing_config_lookup, dfw_section_params, modify_placement):
+    '''Check if FW section placement does not match definition'''
+    if not modify_placement:
+        return False
+    existing_section_list = get_all_request(module, manager_url, mgr_username, mgr_password, validate_certs, '/firewall/sections')                                                
+    for idx, section in enumerate(existing_section_list):
+        if section['display_name'] == dfw_section_params['display_name']:
+            try:
+                if section_placement['operation'] == 'insert_top' and idx != 0:
+                    if section['enforced_on'] == 'VIF':
+                        if existing_section_list[idx - 1]['enforced_on'] == section['enforced_on']:
+                            return True
+                    elif section['enforced_on'] == 'LOGICALROUTER':
+                        if existing_section_list[idx - 1]['applied_tos'] == section['applied_tos']:
+                            return True
+                elif section_placement['operation'] == 'insert_bottom':
+                    if section['enforced_on'] == 'VIF':
+                        if existing_section_list[idx + 1]['display_name'] != 'Default Layer3 Section':
+                            return True
+                    elif section['enforced_on'] == 'LOGICALROUTER':
+                        if existing_section_list[idx + 1]['display_name'] != 'Default LR Layer3 Section':
+                            return True
+                elif section_placement['operation'] == 'insert_after':
+                    if idx == 0:
+                        return True
+                    elif section_placement.__contains__('id') and section_placement['id'] != existing_section_list[idx - 1]['id']:
+                        return True
+                    elif section_placement.__contains__('display_name') and \
+                        existing_config_lookup['FirewallSection'][str(section_placement['display_name'])] != existing_section_list[idx - 1]['id']:
+                        return True
+                elif section_placement['operation'] == 'insert_before':
+                    if section_placement.__contains__('id') and section_placement['id'] != existing_section_list[idx + 1]['id']:
+                        return True
+                    elif section_placement.__contains__('display_name') and \
+                        existing_config_lookup['FirewallSection'][str(section_placement['display_name'])] != existing_section_list[idx + 1]['id']:
+                        return True
+            except KeyError:
+                module.fail_json(msg="Failed when looking up section placement for section [%s] with params [%s]."  % 
+                                 (dfw_section_params['display_name'], section_placement))
+            break
+    return False
+
+def generate_section_placement(module, manager_url, mgr_username, mgr_password, validate_certs, section_placement, 
+                               existing_config_lookup, duplicated_objects, section_name, place_updated):
+    '''Generate option string to post on create or update'''
+    if not section_placement:
+        return ''
+    try:
+        if section_placement['operation'] == 'insert_top' or section_placement['operation'] == 'insert_bottom':
+            return 'operation=' + section_placement['operation']
+        elif section_placement['operation'] == 'insert_after' or section_placement['operation'] == 'insert_before':
+            if section_placement.__contains__('id'):
+                return 'operation=' + section_placement['operation'] + '&id=' + section_placement['id']
+            elif section_placement.__contains__('display_name') and existing_config_lookup['FirewallSection'].__contains__(str(section_placement['display_name'])):
+                if section_placement[str('display_name')] in duplicated_objects['FirewallSection']:
+                    module.fail_json(msg='Firewall section %s exists more than once when trying to assign placement for section %s.' % 
+                                     (section_placement['display_name'], section_name))
+                return 'operation=' + section_placement['operation'] + '&id=' + existing_config_lookup['FirewallSection'][str(section_placement['display_name'])]
+        else:
+            module.fail_json(msg='[%s] is not a valid section plecement operator for section [%s].' % (section_placement['operation'], section_name))
+        module.fail_json(msg='Unable to find section [%s]. when generating placement ID for section [%s].' % 
+                         (section_placement['display_name'], section_name))
+    except KeyError as err:
+        module.fail_json(msg='Unable to find section [%s] when generating section placement. Error [%s]' % 
+                         (section_placement['display_name'], to_native(err)))
+
+def generate_query_params(module, dfw_section_params, manager_url, mgr_username, mgr_password, validate_certs, 
+                          section_placement, updated, existing_config_lookup, duplicated_objects, modify_placement, 
+                          place_updated):
+    '''Allow for different query action depending on what has changed and whether play has modify flag'''
+    section_place_params  = generate_section_placement(module, manager_url, mgr_username, mgr_password,
+                                                       validate_certs, section_placement, existing_config_lookup,
+                                                       duplicated_objects, dfw_section_params['display_name'], place_updated)
+    if place_updated and modify_placement and not updated:
+        dfw_section_params['rules'] = [] # action=revise doesn't support rules, so emptying rules if no changes
+        return '?action=revise&' + section_place_params
+    elif updated:
+        if dfw_section_params['rules'] and place_updated and modify_placement:
+            return '?action=revise_with_rules&' + section_place_params
+        else:
+            return '?action=update_with_rules'
+    else:
+        if dfw_section_params['rules']:
+            return '?action=create_with_rules&' + section_place_params
+        else:
+            if section_place_params != '':
+                return '?' + section_place_params
+            else:
+                return ''
+
+def check_rules_have_unique_names(module, dfw_section_params):
+    '''Check whether all supplied FW rules have unique display names to allow module to be idempotent'''
+    rule_names = set()
+    duplicateed_rule_names = set()
+    for rule in dfw_section_params['rules']:
+        try:
+            if rule['display_name'] in rule_names:
+                duplicateed_rule_names.add(rule['display_name'])
+            else:
+                rule_names.add(rule['display_name'])
+        except KeyError:
+            module.fail_json(msg='Rule does not have a display_name param set [%s].' +
+                                 '\nEnsure all rules have unique names withiin each section' % (rule))
+    if duplicateed_rule_names:
+        module.fail_json(msg='The following rules have duplicate display_names [%s]. ' +
+                             '\nEnsure all rules have unique names withiin each section' % (', '.join(duplicateed_rule_names)))
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(display_name=dict(required=True, type='str'),
+                        host_credential=dict(required=False, type='dict',
+                            username=dict(required=False, type='str'),
+                            password=dict(required=False, type='str', no_log=True),
+                            thumbprint=dict(required=False, type='str', no_log=True)),
+                        applied_tos=dict(required=False, type='list', default=list([]),
+                            target_display_name=dict(required=True, type='str'), # Will insert target_id a runtime
+                            target_type=dict(required=True, type='str', choices=['LogicalPort', 'LogicalSwitch', 
+                                                                                'NSGroup', 'LogicalRouter'])),
+                        description=dict(required=False, type='str'),
+                        rules=dict(required=True, type='list',
+                            display_name=dict(required=True, type='str'), # API does not enforce, but added to all later management.
+                            description=dict(required=False, type='str'),
+                            action=dict(required=True, type='str', choices=['ALLOW', 'DROP', 'REJECT', 'REDIRECT', 
+                                                                            'DO_NOT_REDIRECT']),
+                            applied_tos=dict(required=False, type='list', default=[],
+                                target_display_name=dict(required=True, type='str'), # Will insert target_id a runtime
+                                target_type=dict(required=True, type='str', choices=['LogicalPort', 'LogicalSwitch', 
+                                                                                    'NSGroup'])),
+                            context_profiles=dict(required=False, type='list', default=[],
+                                target_display_name=dict(required=True, type='str'), # Will insert target_id a runtime
+                                target_type=dict(required=True, type='str', choices=['NSProfile'])),
+                            destinations=dict(required=False, type='list', default=[],
+                                target_display_name=dict(required=True, type='str'), # Will insert target_id a runtime
+                                target_type=dict(required=True, type='str', choices=['IPSet', 'LogicalPort', 
+                                                                                    'LogicalSwitch', 'NSGroup'])),
+                            direction=dict(required=False, type='str', choices=['IN', 'OUT', 'IN_OUT']),
+                            disabled=dict(required=False, type='bool'),
+                            ip_protocol=dict(required=False, type='str', choices=['IPV4', 'IPV6', 'IPV4_IPV6']),
+                            logged=dict(required=False, type='bool'),
+                            notes=dict(required=False, type='str'),
+                            resource_type=dict(required=False, type='str', choices=['FirewallRule']),
+                            rule_tag=dict(required=False, type='str'),
+                            services=dict(required=False, type='list', default=[],
+                                target_display_name=dict(required=False, type='str'), # Will insert target_id a runtime
+                                target_type=dict(required=False, type='str', choices=['NSService', 'NSServiceGroup']),
+                                service=dict(required=False, type='list', default=[],
+                                    alg=dict(required=False, type='str', choices=['ORACLE_TNS', 'FTP', 'SUN_RPC_TCP', 
+                                                                                  'SUN_RPC_UDP', 'MS_RPC_TCP', 
+                                                                                  'MS_RPC_UDP', 'NBNS_BROADCAST', 
+                                                                                  'NBDG_BROADCAST', 'TFTP']),
+                                    destination_ports=dict(required=False, type='list'),
+                                    icmp_code=dict(required=False, type='int'),
+                                    icmp_type=dict(required=False, type='int'),
+                                    l4_protocol=dict(required=False, type='str'),
+                                    protocol=dict(required=False, type='str', choices=['ICMPv4', 'ICMPv6']),
+                                    protocol_number=dict(required=False, type='int'),
+                                    resource_type=dict(required=True, type='str', 
+                                                       choices=['ALGTypeNSService', 'IPProtocolNSService', 
+                                                                'L4PortSetNSService', 'ICMPTypeNSService', 
+                                                                'IGMPTypeNSService']),
+                                    source_ports=dict(required=False, type='list')),),
+                            sources=dict(required=False, type='list', default=[],
+                                target_display_name=dict(required=True, type='str'), # Will insert target_id a runtime
+                                target_type=dict(required=True, type='str', choices=['IPSet', 'LogicalPort', 
+                                                                                     'LogicalSwitch', 'NSGroup'])),),
+                        resource_type=dict(required=False, choices=['FirewallSectionRuleList'], 
+                                           default='FirewallSectionRuleList'),
+                        section_placement=dict(required=False, type='dict',
+                            operation=dict(required=True, type='str', choices=['insert_top', 'insert_bottom', 
+                                                                               'insert_after', 'insert_before']),
+                            display_name=dict(required=True, type='str')),
+                        section_type=dict(required=False, choices=['LAYER3'], default='LAYER2, LAYER3'),
+                        state=dict(required=True, choices=['present', 'absent']),
+                        stateful=dict(required=True, type='bool'),
+                        tags=dict(required=False, type='list',
+                                tag=dict(required=False, type='str'),
+                                scope=dict(required=False, type='str')),
+                        modify_placement=dict(required=False, type='bool', default=False))
+                        
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    dfw_section_params = get_dfw_section_params(module.params.copy())
+    state = module.params['state']
+    mgr_hostname = module.params['hostname']
+    mgr_username = module.params['username']
+    mgr_password = module.params['password']
+    validate_certs = module.params['validate_certs']
+    display_name = module.params['display_name']
+    manager_url = 'https://{}/api/v1'.format(mgr_hostname)
+    section_placement = dfw_section_params.pop('section_placement', None)
+    modify_placement = dfw_section_params.pop('modify_placement', None)
+
+    check_rules_have_unique_names(module, dfw_section_params)
+    insert_lists_if_missing(dfw_section_params, ['applied_tos', 'tags'])
+
+    section_dict = get_dfw_section_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, 
+                                                     display_name)
+    section_id, revision = None, None
+    if section_dict:
+        section_id = section_dict['id']
+        revision = section_dict['_revision']
+    
+    if state == 'present':
+        headers = dict(Accept="application/json")
+        headers['Content-Type'] = 'application/json'
+        add_backwards_compatibilty(module, manager_url, mgr_username, mgr_password, validate_certs, dfw_section_params)
+        existing_config_lookup, duplicated_objects = collect_all_existing_config(module, manager_url, mgr_username, 
+                                                                                 mgr_password, validate_certs)
+        update_param_list_with_ids(module, dfw_section_params['applied_tos'], existing_config_lookup, duplicated_objects,
+                                 'DFW section ' + dfw_section_params['display_name'], 'applied_tos')
+        update_rules_list_with_ids(module, dfw_section_params['rules'], existing_config_lookup, 
+                                   ['applied_tos', 'context_profiles', 'destinations', 'services', 'sources'],
+                                   duplicated_objects)
+        updated = check_for_update(module, manager_url, mgr_username, mgr_password, validate_certs, 
+                                   dfw_section_params)
+        place_updated = check_if_section_moved(module, manager_url, mgr_username, mgr_password, validate_certs, 
+                                               section_placement, existing_config_lookup, dfw_section_params,
+                                               modify_placement)   
+        query_params = generate_query_params(module, dfw_section_params, manager_url, mgr_username, mgr_password, 
+                                            validate_certs, section_placement, updated, existing_config_lookup, 
+                                            duplicated_objects, modify_placement, place_updated)
+        updated = updated or place_updated
+        if not dfw_section_params['rules']:
+            dfw_section_params.pop('rules', None)
+        if not updated:            
+            request_data = json.dumps(dfw_section_params)
+            if module.check_mode:
+                module.exit_json(changed=True, debug_out=str(request_data), id='12345')
+            try:
+                if section_id:
+                    module.exit_json(changed=False, id=section_id, 
+                                     message="Firewall Section with display_name [%s] already exist and has not changed." % 
+                                     module.params['display_name'])
+                (rc, resp) = request(manager_url+ '/firewall/sections%s' % query_params, data=request_data, 
+                                     headers=headers, method='POST', url_username=mgr_username, url_password=mgr_password, 
+                                     validate_certs=validate_certs, ignore_errors=True)
+            except Exception as err:
+                module.fail_json(msg="Failed to add node. Request body [%s]. Error[%s]." % (request_data, to_native(err)))
+            #TODO consult VMWare NSBU on invokation rates and build dynamic delay between calls.
+            time.sleep(5)
+            module.exit_json(changed=True, id=resp["id"], body= str(resp), 
+                             message="Firewall Section with display_name %s created succcessfully." % 
+                             module.params['display_name'])
+        else:
+            id = section_id
+            if module.check_mode:
+                module.exit_json(changed=True, debug_out=str(json.dumps(dfw_section_params)), id=id)
+            dfw_section_params['_revision'] = revision # update current revision   
+            request_data = json.dumps(dfw_section_params)
+            try:
+                (rc, resp) = request(manager_url+ '/firewall/sections/%s%s' % (id, query_params), data=request_data, 
+                                     headers=headers, method='POST', url_username=mgr_username, url_password=mgr_password, 
+                                     validate_certs=validate_certs, ignore_errors=True)
+            except Exception as err:
+                module.fail_json(msg="Failed to update Section with display_name %s. Request body [%s]. Error[%s]." % 
+                                 (module.params['display_name'], request_data, to_native(err)))
+            time.sleep(5)
+            module.exit_json(changed=True, id=resp["id"], body= str(resp), 
+                             message="Firewall Section with display_name [%s] updated with params [%s]." % 
+                             (module.params['display_name'], query_params))
+
+    elif state == 'absent':
+        id = section_id
+        if id is None:
+            module.exit_json(changed=False, msg='No Firewall Section exist with display name %s' % display_name)
+        if module.check_mode:
+            module.exit_json(changed=True, debug_out=str(json.dumps(dfw_section_params)), id=id)
+        try:
+            (rc, resp) = request(manager_url + "/firewall/sections/%s?cascade=true" % id, method='DELETE',
+                                  url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs)
+        except Exception as err:
+            module.fail_json(msg="Failed to delete Firewall Section with id %s. Error[%s]." % (id, to_native(err)))
+        time.sleep(5)
+        module.exit_json(changed=True, id=id, message="NG Group with node id %s deleted." % id)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/nsxt_ip_sets.py
+++ b/library/nsxt_ip_sets.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 VMware, Inc.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+DOCUMENTATION = '''
+---
+module: nsxt_ip_sets
+short_description: 'Create an IP set'
+description: "Creates a new IPv4 or IPv6 address set. Required parameters are
+              allocation_ranges and cidr. Optional parameters are display_name,
+              description, dns_nameservers, dns_suffix, and gateway_ip."
+version_added: '2.7'
+author: 'Matt Proud'
+options:
+    hostname:
+        description: 'Deployed NSX manager hostname.'
+        required: true
+        type: str
+    username:
+        description: 'The username to authenticate with the NSX manager.'
+        required: true
+        type: str
+    password:
+        description: 'The password to authenticate with the NSX manager.'
+        required: true
+        type: str
+    display_name:
+        description: 'Display name'
+        required: true
+        type: str
+    state:
+        choices:
+            - present
+            - absent
+        description: "State can be either 'present' or 'absent'.
+                      'present' is used to create or update resource.
+                      'absent' is used to delete resource."
+        required: true
+    ip_addresses:
+        description: "ip_addresses can be IPv4 or IPv6 and they should not overlap. The maximum
+                      number will not exceed 4000."
+        required: false
+        type: 'list'
+    tags:
+        description: 'Opaque identifiers meaningful to the API user'
+        required: false
+        type: str
+   
+'''
+
+EXAMPLES = '''
+- name: Create ip set
+  nsxt_ip_sets:
+    hostname: "10.192.167.137"
+    username: "admin"
+    password: "Admin!23Admin"
+    validate_certs: False
+    display_name: IPset-IPV4-1
+    ip_addresses:
+    - "10.112.201.28"
+    - "10.112.201.64/26"
+    state: "present"
+'''
+
+RETURN = '''# '''
+
+
+import json, time
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request
+from ansible.module_utils._text import to_native
+
+def get_ip_set_params(args=None):
+    args_to_remove = ['state', 'username', 'password', 'port', 'hostname', 'validate_certs']
+    for key in args_to_remove:
+        args.pop(key, None)
+    for key, value in args.copy().items():
+        if value == None:
+            args.pop(key, None)
+    return args
+
+def get_ip_sets(module, manager_url, mgr_username, mgr_password, validate_certs):
+    try:
+      (rc, resp) = request(manager_url+ '/ip-sets', headers=dict(Accept='application/json'),
+                      url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+    except Exception as err:
+      module.fail_json(msg='Error accessing ip sets. Error [%s]' % (to_native(err)))
+    return resp
+
+def get_ip_set_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, display_name):
+    ip_sets = get_ip_sets(module, manager_url, mgr_username, mgr_password, validate_certs)
+    return_ip_set = None
+    for ip_set in ip_sets['results']:
+        if ip_set.__contains__('display_name') and ip_set['display_name'] == display_name:
+            if not return_ip_set: # Handle there being 2 sections created with the same display name
+                return_ip_set = ip_set
+            else:
+                module.fail_json(msg='Section with display name %s exists more than once.' % (display_name))
+    return return_ip_set
+
+def check_for_update(module, manager_url, mgr_username, mgr_password, validate_certs, ip_set_params):
+    existing_ip_set = get_ip_set_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, ip_set_params['display_name'])
+    if existing_ip_set is None:
+        return False
+    if  existing_ip_set.__contains__('ip_addresses') and ip_set_params.__contains__('ip_addresses') and existing_ip_set['ip_addresses'] != ip_set_params['ip_addresses']:
+        return True
+    return False
+
+def main():
+  argument_spec = vmware_argument_spec()
+  argument_spec.update(display_name=dict(required=True, type='str'),
+                        description=dict(required=False, type='str'),
+                        ip_addresses=dict(required=False, type='list'),
+                        tags=dict(required=False, type='str'),
+                        state=dict(required=True, choices=['present', 'absent']))
+
+  module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+  ip_set_params = get_ip_set_params(module.params.copy())
+  state = module.params['state']
+  mgr_hostname = module.params['hostname']
+  mgr_username = module.params['username']
+  mgr_password = module.params['password']
+  validate_certs = module.params['validate_certs']
+  display_name = module.params['display_name']
+  manager_url = 'https://{}/api/v1'.format(mgr_hostname)
+
+  set_dict = get_ip_set_from_display_name (module, manager_url, mgr_username, mgr_password, validate_certs, display_name)
+  set_id, revision = None, None
+  if set_dict:
+    set_id = set_dict['id']
+    revision = set_dict['_revision']
+
+  if state == 'present':
+    headers = dict(Accept="application/json")
+    headers['Content-Type'] = 'application/json'
+    updated = check_for_update(module, manager_url, mgr_username, mgr_password, validate_certs, ip_set_params)
+
+    if not updated:
+      # add the set
+      if module.check_mode:
+          module.exit_json(changed=True, debug_out=str(json.dumps(ip_set_params)), id='12345')
+      request_data = json.dumps(ip_set_params)
+      try:
+          if set_id:
+              module.exit_json(changed=False, id=set_id, message="IP set with display_name %s already exist."% module.params['display_name'])
+          (rc, resp) = request(manager_url+ '/ip-sets', data=request_data, headers=headers, method='POST',
+                                url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+      except Exception as err:
+          module.fail_json(msg="Failed to add ip set. Request body [%s]. Error[%s]." % (request_data, to_native(err)))
+
+      time.sleep(5)
+      module.exit_json(changed=True, id=resp["id"], body= str(resp), message="IP set with display name %s created." % module.params['display_name'])
+    else:
+      if module.check_mode:
+          module.exit_json(changed=True, debug_out=str(json.dumps(ip_set_params)), id=set_id)
+      ip_set_params['_revision']=revision # update current revision
+      request_data = json.dumps(ip_set_params)
+      id = set_id
+      try:
+          (rc, resp) = request(manager_url+ '/ip-sets/%s' % id, data=request_data, headers=headers, method='PUT',
+                                url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+      except Exception as err:
+          module.fail_json(msg="Failed to update ip set with id %s. Request body [%s]. Error[%s]." % (id, request_data, to_native(err)))
+      time.sleep(5)
+      module.exit_json(changed=True, id=resp["id"], body= str(resp), message="ip set with set id %s updated." % id)
+
+  elif state == 'absent':
+    # delete the array
+    id = set_id
+    if id is None:
+        module.exit_json(changed=False, msg='No ip set exist with display name %s' % display_name)
+    if module.check_mode:
+        module.exit_json(changed=True, debug_out=str(json.dumps(ip_set_params)), id=id)
+    try:
+        (rc, resp) = request(manager_url + "/ip-sets/%s" % id, method='DELETE',
+                              url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs)
+    except Exception as err:
+        module.fail_json(msg="Failed to delete ip set with id %s. Error[%s]." % (id, to_native(err)))
+
+    time.sleep(5)
+    module.exit_json(changed=True, object_name=id, message="ip set with set id %s deleted." % id)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/nsxt_ip_sets.py
+++ b/library/nsxt_ip_sets.py
@@ -82,7 +82,7 @@ RETURN = '''# '''
 
 import json, time
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request
+from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request, request_get_all
 from ansible.module_utils._text import to_native
 
 def get_ip_set_params(args=None):
@@ -96,16 +96,16 @@ def get_ip_set_params(args=None):
 
 def get_ip_sets(module, manager_url, mgr_username, mgr_password, validate_certs):
     try:
-      (rc, resp) = request(manager_url+ '/ip-sets', headers=dict(Accept='application/json'),
+      (rc, resp) = request_get_all(manager_url+ '/ip-sets', headers=dict(Accept='application/json'),
                       url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
     except Exception as err:
       module.fail_json(msg='Error accessing ip sets. Error [%s]' % (to_native(err)))
-    return resp
+    return resp['results']
 
 def get_ip_set_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, display_name):
     ip_sets = get_ip_sets(module, manager_url, mgr_username, mgr_password, validate_certs)
     return_ip_set = None
-    for ip_set in ip_sets['results']:
+    for ip_set in ip_sets:
         if ip_set.__contains__('display_name') and ip_set['display_name'] == display_name:
             if not return_ip_set: # Handle there being 2 sections created with the same display name
                 return_ip_set = ip_set

--- a/library/nsxt_ip_sets_facts.py
+++ b/library/nsxt_ip_sets_facts.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 VMware, Inc.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: nsxt_ip_sets_facts
+short_description: List IP Sets
+description: Returns information about the configured IP Sets. Information
+             includes the display name and description of the IP Set and the details of
+             each of the IP Allocation.
+
+version_added: "2.7"
+author: Rahul Raghuvanshi
+options:
+    hostname:
+        description: Deployed NSX manager hostname.
+        required: true
+        type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+
+'''
+
+EXAMPLES = '''
+- name: List IP Sets
+  nsxt_ip_sets_facts:
+    hostname: "10.192.167.137"
+    username: "admin"
+    password: "Admin!23Admin"
+    validate_certs: False
+'''
+
+RETURN = '''# '''
+
+import json
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request
+from ansible.module_utils.urls import open_url, fetch_url
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+
+def main():
+  argument_spec = vmware_argument_spec()
+
+  module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+  mgr_hostname = module.params['hostname']
+  mgr_username = module.params['username']
+  mgr_password = module.params['password']
+  validate_certs = module.params['validate_certs']
+
+  manager_url = 'https://{}/api/v1'.format(mgr_hostname)
+
+  changed = False
+  try:
+    (rc, resp) = request(manager_url+ '/ip-sets', headers=dict(Accept='application/json'),
+                    url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+  except Exception as err:
+    module.fail_json(msg='Error accessing list of ip sets. Error [%s]' % (to_native(err)))
+
+  module.exit_json(changed=changed, **resp)
+if __name__ == '__main__':
+	main()

--- a/library/nsxt_ns_groups.py
+++ b/library/nsxt_ns_groups.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 VMware, Inc.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': 'xx',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: nsxt_ns_groups
+short_description: Create and update NS Groups
+description:  Creates an NS Group with either static or dynamic membership.
+              Reference the API guide for which params can be used with which operations.
+
+version_added: "2.7"
+author: Matt Proud
+options:
+    hostname:
+        description: Deployed NSX manager hostname.
+        required: true
+        type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+    display_name:
+        description: Display name
+        required: true
+        type: str
+    members:
+        description: 'List of members. Must conform to NSGroupSimpleExpression schema.'
+        required: False
+        type: list
+        op: 
+            choices: ['EQUALS', 'CONTAINS', 'STARTSWITH', 'ENDSWITH', 'NOTEQUALS']
+            description: "Operator used to check value against resource type"
+            required: True
+            type: str
+        resource_type: 
+            choices: ['NSGroupSimpleExpression']
+            description: "Simple property which must be passed with all members"
+            required: True
+            type: str
+        target_property: 
+            description: "Object property used to identify. See API guide for details."
+            required: True
+            type: str
+        target_type: 
+            choices: ['NSGroup', 'IPSet', 'MACSet', 'LogicalSwitch', 'LogicalPort', 'VirtualMachine', 
+                      'DirectoryGroup', 'VirtualNetworkInterface', 'TransportNode']
+            description: "Type of target object which is supported"
+            required: True
+            type: str
+        value: 
+            description: "Value used to identify member. This can be the unique object ID, which is 'id'
+                          for most objects. Virtual machine uses 'external_id'.
+                          Module supports looking up object IDs by name, but target_property must still
+                          be left as ID."
+            required: True
+            type: str
+    membership_criteria:
+        description: 'List of membership criteria. Members must conform to NSGroupTagExpression or 
+                      NSGroupComplexExpression schema.'
+        required: False
+        type: list
+        resource_type: 
+            choices: ['NSGroupTagExpression', 'NSGroupComplexExpression']
+            description: "Simple property which must be passed with all members"
+            required: True
+            type: str
+        target_type: 
+            description: "Object property used to identify. See API guide for details."
+            required: False
+            type: str
+        scope:
+            description: "Scope of objects to filter for"
+            required: False
+            type: str
+        scope_op:
+            description: "Operator to apply to the tag. Defaults to EQUALS. See API guide for options."
+            required: False
+            type: str
+        tag:
+            description: "Tag used to filter against"
+            required: False
+            type: str
+        tag_op:
+            description: "Operator to apply to the tag. Defaults to EQUALS. See API guide for options."
+            required: False
+            type: str
+        expressions:
+            description: "List of expressions. Minimum 2, maximum 5. Use when resource_type is NSGroupComplexExpression"
+            required: False
+            type: list
+            resource_type: 
+                choices: ['NSGroupTagExpression']
+                description: "Simple property which must be passed with all members"
+                required: True
+                type: str
+            target_type: 
+                choices: ['LogicalSwitch', 'LogicalPort', 'VirtualMachine', ]
+                description: "Object property used to identify. See API guide for details."
+                required: True
+                type: str
+            scope:
+                description: "Scope of objects to filter for"
+                required: True
+                type: str
+            scope_op:
+                description: "Operator to apply to the tag. Defaults to EQUALS. See API guide for options."
+                required: False
+                type: str
+            tag:
+                description: "Tag used to filter against"
+                required: True
+                type: str
+            tag_op:
+                description: "Operator to apply to the tag. Defaults to EQUALS. See API guide for options."
+                required: False
+                type: str
+    resource_type:
+        choices: ['NSGroup']
+        description: Specifies NSGroup as object type
+        required: False
+        type: str
+    state:
+        choices:
+        - present
+        - absent
+        description: "State can be either 'present' or 'absent'. 
+                      'present' is used to create or update resource. 
+                      'absent' is used to delete resource."
+        required: true
+'''
+
+EXAMPLES = '''
+- name: Add NS Group with membership criteria
+  nsxt_ns_group:
+    hostname: "10.192.167.137"
+    username: "admin"
+    password: "Admin!23Admin"
+    validate_certs: False
+    display_name: "ns_with_criteria"
+    resource_type: NSGroup
+    membership_criteria:
+      - resource_type: NSGroupTagExpression
+        target_type: "LogicalSwitch"
+        scope: "S1"
+        tag: "T1"
+      - resource_type: NSGroupComplexExpression
+        expressions:
+          - resource_type: NSGroupTagExpression
+            target_type: "LogicalPort"
+            scope: "S1"
+            tag: "T1"
+          - resource_type: NSGroupTagExpression
+            target_type: "LogicalPort"
+            scope: "S2"
+            tag: "T2"
+    state: "present"
+
+
+- name: Add NS Group with static members
+  nsxt_ns_group:
+    hostname: "10.192.167.137"
+    username: "admin"
+    password: "Admin!23Admin"
+    validate_certs: False
+    display_name: "ns_with_criteria"
+    resource_type: NSGroup
+  members:
+    - resource_type: NSGroupSimpleExpression
+      target_property: id
+      op: EQUALS
+      target_type: IPSet
+      value: "ips_test1"
+    - resource_type: NSGroupSimpleExpression
+      target_property: id
+      op: EQUALS
+      target_type: IPSet
+      value: "ips_test2"
+    state: "present"
+'''
+
+RETURN = '''# '''
+
+import json, time
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request
+from ansible.module_utils._text import to_native
+from collections import Counter
+
+
+def get_ns_group_params(args=None):
+    args_to_remove = ['state', 'username', 'password', 'port', 'hostname', 'validate_certs']
+    for key in args_to_remove:
+        args.pop(key, None)
+    for key, value in args.copy().items():
+        if value == None:
+            args.pop(key, None)
+    return args
+
+def get_ns_groups(module, manager_url, mgr_username, mgr_password, validate_certs):
+    try:
+      (rc, resp) = request(manager_url+ '/ns-groups', headers=dict(Accept='application/json'),
+                      url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+    except Exception as err:
+      module.fail_json(msg='Error accessing NS Group. Error [%s]' % (to_native(err)))
+    return resp
+
+def get_ns_group_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, display_name):
+    ns_groups = get_ns_groups(module, manager_url, mgr_username, mgr_password, validate_certs)
+    return_ns_group = None
+    for ns_group in ns_groups['results']:
+        if ns_group.__contains__('display_name') and ns_group['display_name'] == display_name:
+            if not return_ns_group: # Handle there being 2 sections created with the same display name
+                return_ns_group = ns_group
+            else:
+                module.fail_json(msg='Section with display name %s exists more than once.' % (display_name))
+    return return_ns_group
+
+def get_id_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, endpoint, display_name, exit_if_not_found=True, id_notation='id'):
+    try:
+      (rc, resp) = request(manager_url+ endpoint, headers=dict(Accept='application/json'),
+                      url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+    except Exception as err:
+      module.fail_json(msg='Error accessing id for display name %s. Error [%s]' % (display_name, to_native(err)))
+
+    for result in resp['results']:
+        if result.__contains__('display_name') and result['display_name'] == display_name:
+            return result[id_notation]
+    if exit_if_not_found:
+        module.fail_json(msg='No id exist with display name %s' % display_name)
+
+def update_params_with_id (module, manager_url, mgr_username, mgr_password, validate_certs, ns_group_params ):
+    endpoint_lookup = {'NSGroup': '/ns-groups', 'IPSet': '/ip-sets', 'MACSet': '/mac-sets', 'LogicalSwitch': '/logical-switches', 
+                          'LogicalPort': '/logical-ports', 'VirtualMachine': '/fabric/virtual-machines', 'TransportNode': '/transport-nodes'}
+    if ns_group_params['members']:
+        for counter, member in enumerate(ns_group_params['members']):
+          if member['target_type'] in endpoint_lookup.keys() and (member['target_property'] == 'id' or member['target_property'] == 'external_id'):
+            value = ns_group_params['members'][counter].pop('value', None)
+            if member['target_property'] == 'id':
+              ns_group_params['members'][counter]['value'] = get_id_from_display_name (module, manager_url, mgr_username, mgr_password, validate_certs,
+                          endpoint_lookup[member['target_type']], value)
+            elif member['target_property'] == 'external_id':
+              ns_group_params['members'][counter]['value'] = get_id_from_display_name (module, manager_url, mgr_username, mgr_password, validate_certs,
+                          endpoint_lookup[member['target_type']], value, True, 'external_id')
+    return ns_group_params
+
+def add_equals_operator_if_missing(dict_to_check):
+    addition_string = ''
+    if not dict_to_check.__contains__('tag_op'):
+        addition_string += 'EQUALS'
+    if not dict_to_check.__contains__('scope_op'):
+        addition_string += 'EQUALS'
+    return addition_string if addition_string <> '' else ''
+
+# All values are extracted for each membership_criteria and a sorted string is built. 
+def extract_membership_criteria_list(membership_criteria_list):
+    output_list = []
+    for membership_criteria in membership_criteria_list:
+        if membership_criteria['resource_type'] == 'NSGroupComplexExpression':
+            for expression in membership_criteria['expressions']:
+                item_string = add_equals_operator_if_missing(expression)
+                for value in expression.values():
+                    item_string += value
+                output_list.append(''.join(sorted(item_string)))
+        elif membership_criteria['resource_type'] == 'NSGroupTagExpression':
+            item_string = add_equals_operator_if_missing(membership_criteria)
+            for value in membership_criteria.values():
+                item_string += value
+            output_list.append(''.join(sorted(item_string)))
+    return output_list
+
+def check_for_update(module, manager_url, mgr_username, mgr_password, validate_certs, ns_group_params):
+    existing_ns_group = get_ns_group_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, 
+                                                       ns_group_params['display_name'])
+    if not existing_ns_group:
+        return False
+    # Compares the uniqie value for all static members, which is the object ID.
+    if ns_group_params['members']:
+        if len(ns_group_params['members']) <> len(existing_ns_group['members']):
+            return True
+        existing_members = [d['value'] for d in existing_ns_group['members'] if 'value' in d]
+        new_members = [d['value'] for d in ns_group_params['members'] if 'value' in d]
+        if not Counter(existing_members) == Counter(new_members):
+            return True
+    # Membership criterial has no unique keys, so all values need to be compared. Lists are generated with sorted strings.
+    if ns_group_params['membership_criteria']:
+        if len(ns_group_params['membership_criteria']) <> len(existing_ns_group['membership_criteria']):
+            return True
+        existings_membership_criteria_list = extract_membership_criteria_list(existing_ns_group['membership_criteria'])
+        new_membership_criteria_list = extract_membership_criteria_list(ns_group_params['membership_criteria'])
+        if not Counter(existings_membership_criteria_list) == Counter(new_membership_criteria_list):
+            return True
+    return False
+
+def main():
+  argument_spec = vmware_argument_spec()
+  argument_spec.update(display_name=dict(required=True, type='str'),
+                    host_credential=dict(required=False, type='dict',
+                        username=dict(required=False, type='str'),
+                        password=dict(required=False, type='str', no_log=True),
+                        thumbprint=dict(required=False, type='str', no_log=True)),
+                    members=dict(required=False, type='list', 
+                        op=dict(required=True, type='str', choices=['EQUALS', 'CONTAINS', 'STARTSWITH', 'ENDSWITH', 'NOTEQUALS']),
+                        resource_type=dict(required=True, type='str', choices=['NSGroupSimpleExpression']),
+                        target_property=dict(required=True, type='str'),
+                        target_type=dict(required=True, type='str', choices=['NSGroup', 'IPSet', 'MACSet', 'LogicalSwitch', 'LogicalPort', 
+                                                                              'VirtualMachine', 'DirectoryGroup', 'VirtualNetworkInterface', 'TransportNode']),
+                        value=dict(required=True, type='str', choices=['NSGroupSimpleExpression'])),
+                    membership_criteria=dict(required=False, type='list',
+                        expressions=dict(required=False, type='list',
+                            resource_type=dict(required=True, type='str', choices=['NSGroupSimpleExpression']),
+                            scope=dict(required=True, type='str'),
+                            scope_op=dict(required=False, type='str', choices=['EQUALS']),
+                            tag=dict(required=True, type='str'),
+                            tag_op=dict(required=False, type='str', choices=['EQUALS', 'CONTAINS', 'STARTSWITH', 'ENDSWITH']),
+                            target_type=dict(required=True, type='str', choices=['IPSet', 'LogicalSwitch', 'LogicalPort', 'VirtualMachine', 'TransportNode'])),
+                        resource_type=dict(required=False, type='str', choices=['NSGroupSimpleExpression']),
+                        scope=dict(required=False, type='str'),
+                        scope_op=dict(required=False, type='str', choices=['EQUALS']),
+                        tag=dict(required=False, type='str'),
+                        tag_op=dict(required=False, type='str', choices=['EQUALS', 'CONTAINS', 'STARTSWITH', 'ENDSWITH']),
+                        target_type=dict(required=True, type='str', choices=['IPSet', 'LogicalSwitch', 'LogicalPort', 'VirtualMachine', 'TransportNode']),),
+                    resource_type=dict(required=False, type='str', default='NSGroup'),
+                    state=dict(required=True, choices=['present', 'absent']))
+
+  module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+  
+  ns_group_params = get_ns_group_params(module.params.copy())
+  
+  state = module.params['state']
+  mgr_hostname = module.params['hostname']
+  mgr_username = module.params['username']
+  mgr_password = module.params['password']
+  validate_certs = module.params['validate_certs']
+  display_name = module.params['display_name']
+  manager_url = 'https://{}/api/v1'.format(mgr_hostname)
+
+  if ns_group_params['members'] == ['']:
+    ns_group_params['members'] = []
+  if ns_group_params['membership_criteria'] == ['']:
+    ns_group_params['membership_criteria'] = []
+
+  group_dict = get_ns_group_from_display_name (module, manager_url, mgr_username, mgr_password, validate_certs, display_name)
+  group_id, revision = None, None
+  if group_dict:
+    group_id = group_dict['id']
+    revision = group_dict['_revision']
+
+  if state == 'present':
+    headers = dict(Accept="application/json")
+    headers['Content-Type'] = 'application/json'
+    body = update_params_with_id (module, manager_url, mgr_username, mgr_password, validate_certs, ns_group_params)
+    updated = check_for_update(module, manager_url, mgr_username, mgr_password, validate_certs, body)
+
+    if not updated:
+      request_data = json.dumps(ns_group_params)
+      if module.check_mode:
+          module.exit_json(changed=True, debug_out=str(request_data), id='12345')
+      try:
+          if group_id:
+              module.exit_json(changed=False, id=group_id, message="NS Group with display_name %s already exist."% module.params['display_name'])
+          (rc, resp) = request(manager_url+ '/ns-groups', data=request_data, headers=headers, method='POST',
+                                url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+      except Exception as err:
+                module.fail_json(msg="Failed to add node. Request body [%s]. Error[%s]." % (request_data, to_native(err)))
+      time.sleep(5)
+      module.exit_json(changed=True, id=resp["id"], body= str(resp), message="NS Group with display name %s created succcessfully." % module.params['display_name'])
+    else:
+      if module.check_mode:
+          module.exit_json(changed=True, debug_out=str(json.dumps(ns_group_params)), id=id)
+
+      ns_group_params['_revision'] = revision # update current revision
+      request_data = json.dumps(ns_group_params)
+      id = group_id
+      try:
+          (rc, resp) = request(manager_url+ '/ns-groups/%s' % id, data=request_data, headers=headers, method='PUT',
+                                url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+      except Exception as err:
+          module.fail_json(msg="Failed to update node wit id %s. Request body [%s]. Error[%s]." % (id, request_data, to_native(err)))
+      time.sleep(5)
+      module.exit_json(changed=True, id=resp["id"], body= str(resp), message="NS Group with node id %s updated." % id)
+
+  elif state == 'absent':
+    # delete the array
+    id = group_id
+    if id is None:
+        module.exit_json(changed=False, msg='No NS Group exist with display name %s' % display_name)
+    if module.check_mode:
+        module.exit_json(changed=True, debug_out=str(json.dumps(ns_group_params)), id=id)
+    try:
+        (rc, resp) = request(manager_url + "/ns-groups/%s" % id, method='DELETE',
+                              url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs)
+    except Exception as err:
+        module.fail_json(msg="Failed to delete NS Group with id %s. Error[%s]." % (id, to_native(err)))
+    time.sleep(5)
+    module.exit_json(changed=True, id=id, message="NG Group with node id %s deleted." % id)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/nsxt_ns_groups_facts.py
+++ b/library/nsxt_ns_groups_facts.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 VMware, Inc.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: nsxt_ip_sets_facts
+short_description: List NS Groups
+description: Returns information about the configured NS Groups. Information
+             includes the display name, all static configured members and 
+             dynamic membership criteria
+
+version_added: "2.7"
+author: Rahul Raghuvanshi
+options:
+    hostname:
+        description: Deployed NSX manager hostname.
+        required: true
+        type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+
+'''
+
+EXAMPLES = '''
+- name: List IP Sets
+  nsxt_ip_sets_facts:
+    hostname: "10.192.167.137"
+    username: "admin"
+    password: "Admin!23Admin"
+    validate_certs: False
+'''
+
+RETURN = '''# '''
+
+import json
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request
+from ansible.module_utils.urls import open_url, fetch_url
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+
+def main():
+  argument_spec = vmware_argument_spec()
+
+  module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+  mgr_hostname = module.params['hostname']
+  mgr_username = module.params['username']
+  mgr_password = module.params['password']
+  validate_certs = module.params['validate_certs']
+
+  manager_url = 'https://{}/api/v1'.format(mgr_hostname)
+
+  changed = False
+  try:
+    (rc, resp) = request(manager_url+ '/ns-groups', headers=dict(Accept='application/json'),
+                    url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+  except Exception as err:
+    module.fail_json(msg='Error accessing list of ip sets. Error [%s]' % (to_native(err)))
+
+  module.exit_json(changed=changed, **resp)
+if __name__ == '__main__':
+	main()

--- a/library/nsxt_services.py
+++ b/library/nsxt_services.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 VMware, Inc.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+DOCUMENTATION = '''
+---
+module: nsxt_services
+short_description: 'Create a Service'
+description: "Creates a new Service. Required parameters are display_name,
+              ports and state. Display_name is required to make module idempotent"
+version_added: '2.7'
+author: 'Matt Proud'
+options:
+    hostname:
+        description: 'Deployed NSX manager hostname.'
+        required: true
+        type: str
+    username:
+        description: 'The username to authenticate with the NSX manager.'
+        required: true
+        type: str
+    password:
+        description: 'The password to authenticate with the NSX manager.'
+        required: true
+        type: str
+    description:
+        description: Description of this resource.
+        required: False
+        type: str
+    display_name:
+        description: 'Display name'
+        required: true
+        type: str
+    nsservice_element:
+        description: "Custom services should conform to ALGTypeNSService, ICMPTypeNSService, 
+                      IGMPTypeNSService, IPProtocolNSService or L4PortSetNSService schemas."
+        required: True
+        type: 'dict'
+        alg:
+            choices: ['ORACLE_TNS', 'FTP', 'SUN_RPC_TCP', 'SUN_RPC_UDP', 'MS_RPC_TCP', 'MS_RPC_UDP', 
+                        'NBNS_BROADCAST', 'NBDG_BROADCAST', 'TFTP']
+            description: 'The Application Layer Gateway (ALG) protocol. Consult the documentation for edge
+                            rules as not all protocols are supported on edge firewalls.' 
+            required: False
+            type: str 
+        destination_ports:
+            description: List of ports as integers. Max 15
+            required: False
+            type: list
+        icmp_code:
+            description: ICMP message code
+            required: False
+            type: int
+        icmp_type:
+            description: ICMP message type
+            required: False
+            type: int
+        l4_protocol:
+        protocol:
+            choices: ['ICMPv4', 'ICMPv6']
+            description: ICMP protocol type
+            required: False
+            type: list
+        protocol_number:
+            description: The IP protocol number
+            required: False
+            type: int
+        resource_type:
+            choices: ['ALGTypeNSService', 'IPProtocolNSService', 'L4PortSetNSService', 'ICMPTypeNSService',
+                        'IGMPTypeNSService']
+            description: Type of service.
+            required: False
+            type: list
+        source_ports:
+            description: List of ports as integers. Max 15
+            required: False
+            type: list
+    state:
+        choices:
+            - present
+            - absent
+        description: "State can be either 'present' or 'absent'.
+                      'present' is used to create or update resource.
+                      'absent' is used to delete resource."
+        required: true
+    tags:
+        description: 'Opaque identifiers meaningful to the API user. Max 30 items'
+        required: false
+        type: list
+        scope:
+            description: 'Tag scope. Tag searches may optionally be restricted by scope. Max len 128 charactors.'
+            required: true
+            type: str
+        tag:
+            description: ' 	Tag value. Identifier meaningful to user. Max len 128 charactors.'
+            required: true
+            type: str
+    
+'''
+
+EXAMPLES = '''
+- name: Create ip set
+  nsxt_services:
+    hostname: "10.192.167.137"
+    username: "admin"
+    password: "Admin!23Admin"
+    validate_certs: False
+    description: "HTTPS Alt port example"
+    display_name: HTTPS-ALT
+    nsservice_element:
+        destination_ports:
+        - '8443'
+        l4_protocol: TCP
+        resource_type: L4PortSetNSService
+    state: "present"
+    tags:
+    - scope: exmaple
+      tag: https_alt
+'''
+
+RETURN = '''# '''
+
+
+import json, time, copy
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request
+from ansible.module_utils._text import to_native
+
+
+def get_service_params(args=None):
+    '''Strip args from pararms that don't get passed within the JSON'''
+    args_to_remove = ['state', 'username', 'password', 'port', 'hostname', 'validate_certs']
+    for key in args_to_remove:
+        args.pop(key, None)
+    for key, value in args.copy().items():
+        if value == None:
+            args.pop(key, None)
+    return args
+
+def get_all_request(module, manager_url, mgr_username, mgr_password, validate_certs, endpoint):
+    '''Handle the API service respondign with a cursor and make subsequent request.'''
+    try:
+        output_list = []
+        cursor = ''
+        while True:
+            (rc, resp) = request(manager_url + endpoint + cursor, headers=dict(Accept='application/json'),
+                                 url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, 
+                                 ignore_errors=True)
+            if resp['results']:
+                output_list += resp['results']
+            if resp.__contains__('cursor'):
+                cursor = '?cursor=' + resp['cursor']
+            else:
+                break
+        return output_list
+    except Exception as err:
+        module.fail_json(msg='Error accessing endpoint %s. \nError [%s]' % (endpoint, to_native(err)))
+
+def get_service_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, display_name):
+    '''Retrn service dict from display name if display name is unique'''
+    services = get_all_request(module, manager_url, mgr_username, mgr_password, validate_certs, '/ns-services')
+    return_service = None
+    for service in services:
+        if service.__contains__('display_name') and service['display_name'] == display_name:
+            if not return_service: # Handle there being 2 sections created with the same display name
+                return_service = service
+            else:
+                module.fail_json(msg='Section with display name %s exists twice.' % (display_name))
+    return return_service
+
+def flatten_list_to_string(nsservice_element):
+    '''Flatten sorted list of ports to a string to a concatenated string allow comparison'''
+    for list_type in ['sourse_ports', 'destination_ports']:
+        if nsservice_element.__contains__(list_type):
+            ports_string = ''
+            for port in sorted(nsservice_element[list_type]):
+                ports_string += str(port) + ','
+            nsservice_element[list_type] = ports_string
+
+def convert_tag_dict_to_string(tag_list):
+    '''Convert list of tag dicts to a list of strings'''
+    existing_tag_strings = []
+    for tag in tag_list:
+        tag_string = ''
+        for key in ['tag', 'scope']:
+            if tag.__contains__(key) and tag[key] != '':
+                tag_string += key + tag[key]
+        existing_tag_strings.append(tag_string)
+    return existing_tag_strings
+
+def compare_tags(module, existing_tags, new_tags):
+    '''Compare tags as lists of strings to check for differences'''
+    if len(existing_tags) != len(new_tags):
+        return True
+    
+    # Convert tag dictionaries to strings to allow list compare and account of empty values in either element.
+    existing_tag_strings = convert_tag_dict_to_string(existing_tags)
+    new_tag_string = convert_tag_dict_to_string(new_tags)
+    if existing_tag_strings != new_tag_string:
+        return True
+
+    return False
+
+def check_for_update(module, manager_url, mgr_username, mgr_password, validate_certs, service_params):
+    '''Check if any element of a section has changed'''
+    existing_service = get_service_from_display_name(module, manager_url, mgr_username, mgr_password, validate_certs, 
+                                                     service_params['display_name'])
+    if existing_service is None:
+        return False
+
+    # service_params must be deep copied otherwise pop removes globally.
+    copy_service_params = copy.deepcopy(service_params)
+    copy_nsservice_element = copy_service_params.pop('nsservice_element', [])
+    existing_nsservice_element = existing_service.pop('nsservice_element', None)
+    copy_tags = copy_service_params.pop('tags', [])
+    existing_tags = existing_service.pop('tags', [])
+
+    # Flatten list of ports for ALGTypeNSService and L4PortSetNSService so that can be easily compared
+    flatten_list_to_string(copy_nsservice_element)
+    flatten_list_to_string(existing_nsservice_element)
+
+    # Check to ensure that all keys and values in the base of the params match the existing configuration.
+    if not all(k in existing_service and copy_service_params[k] == existing_service[k] for k in copy_service_params):
+        return True
+    
+    # Check to ensure that all keys and values nsservice_element match the existing configration.
+    if not all(k in existing_nsservice_element and copy_nsservice_element[k] == existing_nsservice_element[k] for k in copy_nsservice_element):
+        return True
+    
+    # Compare list of tags as strings
+    if compare_tags(module, existing_tags, copy_tags):
+        return True
+
+    return False
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(display_name=dict(required=True, type='str'),
+                            description=dict(required=False, type='str'),
+                            nsservice_element=dict(required=True, type='dict',
+                                alg=dict(required=False, type='str', choices=['ORACLE_TNS', 'FTP', 'SUN_RPC_TCP', 
+                                                                            'SUN_RPC_UDP', 'MS_RPC_TCP', 'MS_RPC_UDP', 
+                                                                            'NBNS_BROADCAST', 'NBDG_BROADCAST', 'TFTP']),
+                                destination_ports=dict(required=False, type='list'),
+                                icmp_code=dict(required=False, type='int'),
+                                icmp_type=dict(required=False, type='int'),
+                                l4_protocol=dict(required=False, type='str'),
+                                protocol=dict(required=False, type='str', choices=['ICMPv4', 'ICMPv6']),
+                                protocol_number=dict(required=False, type='int'),
+                                resource_type=dict(required=True, type='str', 
+                                                    choices=['ALGTypeNSService', 'IPProtocolNSService', 
+                                                            'L4PortSetNSService', 'ICMPTypeNSService', 'IGMPTypeNSService']),
+                                source_ports=dict(required=False, type='list')),
+                            resource_type=dict(required=False, type='str', default='NSService'),
+                            state=dict(required=True, choices=['present', 'absent']),
+                            tags=dict(required=False, type='list',
+                                tag=dict(required=False, type='str'),
+                                scope=dict(required=False, type='str')))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    service_params = get_service_params(module.params.copy())
+    state = module.params['state']
+    mgr_hostname = module.params['hostname']
+    mgr_username = module.params['username']
+    mgr_password = module.params['password']
+    validate_certs = module.params['validate_certs']
+    display_name = module.params['display_name']
+    manager_url = 'https://{}/api/v1'.format(mgr_hostname)
+
+    service_dict = get_service_from_display_name (module, manager_url, mgr_username, mgr_password, validate_certs, 
+                                                  display_name)
+    service_id, revision = None, None
+    if service_dict:
+        service_id = service_dict['id']
+        revision = service_dict['_revision']
+
+    if state == 'present':
+        headers = dict(Accept="application/json")
+        headers['Content-Type'] = 'application/json'
+        updated = check_for_update(module, manager_url, mgr_username, mgr_password, validate_certs, service_params)
+
+        if not updated:
+            if module.check_mode:
+                module.exit_json(changed=True, debug_out=str(json.dumps(service_params)), id='12345')
+            request_data = json.dumps(service_params)
+            try:
+                if service_id:
+                    module.exit_json(changed=False, id=service_id, message="Service with display_name %s already exist." % 
+                                     module.params['display_name'])
+                (rc, resp) = request(manager_url+ '/ns-services', data=request_data, headers=headers, method='POST',
+                                     url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, 
+                                     ignore_errors=True)
+            except Exception as err:
+                module.fail_json(msg="Failed to add service. Request body [%s]. Error[%s]." % (request_data, to_native(err)))
+
+            time.sleep(5)
+            module.exit_json(changed=True, id=resp["id"], body= str(resp), message="Service with display name %s created." % 
+                             module.params['display_name'])
+        else:
+            if module.check_mode:
+                module.exit_json(changed=True, debug_out=str(json.dumps(service_params)), id=service_id)
+            service_params['_revision']=revision # update current revision
+            request_data = json.dumps(service_params)
+            id = service_id
+            try:
+                (rc, resp) = request(manager_url+ '/ns-services/%s' % id, data=request_data, headers=headers, method='PUT',
+                                        url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, 
+                                        ignore_errors=True)
+            except Exception as err:
+                module.fail_json(msg="Failed to update service with id %s. Request body [%s]. Error[%s]." % 
+                                 (id, request_data, to_native(err)))
+            time.sleep(5)
+            module.exit_json(changed=True, id=resp["id"], body= str(resp), message="Service with id %s updated." % id)
+
+    elif state == 'absent':
+        # delete the array
+        id = service_id
+        if id is None:
+            module.exit_json(changed=False, msg='No service exist with display name %s' % display_name)
+        if module.check_mode:
+            module.exit_json(changed=True, debug_out=str(json.dumps(service_params)), id=id)
+        try:
+            (rc, resp) = request(manager_url + "/ns-services/%s" % id, method='DELETE',
+                                url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs)
+        except Exception as err:
+            module.fail_json(msg="Failed to delete service with id %s. Error[%s]." % (id, to_native(err)))
+
+        time.sleep(5)
+        module.exit_json(changed=True, object_name=id, message="Service with id %s deleted." % id)
+
+
+if __name__ == '__main__':
+    main()

--- a/library/nsxt_services_facts.py
+++ b/library/nsxt_services_facts.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 VMware, Inc.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+# BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: nsxt_services_facts
+short_description: List IP Sets
+description: Returns information about the configured services. 
+
+version_added: "2.7"
+author: Rahul Raghuvanshi
+options:
+    hostname:
+        description: Deployed NSX manager hostname.
+        required: true
+        type: str
+    username:
+        description: The username to authenticate with the NSX manager.
+        required: true
+        type: str
+    password:
+        description: The password to authenticate with the NSX manager.
+        required: true
+        type: str
+
+'''
+
+EXAMPLES = '''
+- name: List IP Sets
+  nsxt_services_facts:
+    hostname: "10.192.167.137"
+    username: "admin"
+    password: "Admin!23Admin"
+    validate_certs: False
+'''
+
+RETURN = '''# '''
+
+import json
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware_nsxt import vmware_argument_spec, request
+from ansible.module_utils.urls import open_url, fetch_url
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+
+def main():
+  argument_spec = vmware_argument_spec()
+
+  module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+  mgr_hostname = module.params['hostname']
+  mgr_username = module.params['username']
+  mgr_password = module.params['password']
+  validate_certs = module.params['validate_certs']
+
+  manager_url = 'https://{}/api/v1'.format(mgr_hostname)
+
+  changed = False
+  try:
+    (rc, resp) = request(manager_url+ '/ns-services', headers=dict(Accept='application/json'),
+                    url_username=mgr_username, url_password=mgr_password, validate_certs=validate_certs, ignore_errors=True)
+  except Exception as err:
+    module.fail_json(msg='Error accessing list of services. Error [%s]' % (to_native(err)))
+
+  module.exit_json(changed=changed, **resp)
+if __name__ == '__main__':
+	main()

--- a/module_utils/vmware_nsxt.py
+++ b/module_utils/vmware_nsxt.py
@@ -25,6 +25,24 @@ def vmware_argument_spec():
         validate_certs=dict(type='bool', required=False, default=True),
     )
 
+def request_get_all(url, data=None, headers=None, method='GET', use_proxy=True,
+            force=False, last_mod_time=None, timeout=300, validate_certs=True,
+            url_username=None, url_password=None, http_agent=None, force_basic_auth=True, ignore_errors=False):
+    output_list = []
+    cursor = ''
+    while True:
+        (rc, resp) = request(url=url + cursor, headers=headers, method='GET', use_proxy=use_proxy,
+                                                    force=force, last_mod_time=last_mod_time, timeout=timeout, validate_certs=validate_certs,
+                                                    url_username=url_username, url_password=url_password, http_agent=http_agent, 
+                                                    force_basic_auth=True, ignore_errors=ignore_errors)
+        if resp['results']:
+            output_list += resp['results']
+        if resp.__contains__('cursor'):
+            cursor = '?cursor=' + resp['cursor']
+        else:
+            break
+    return rc, {'results': output_list}
+
 def request(url, data=None, headers=None, method='GET', use_proxy=True,
             force=False, last_mod_time=None, timeout=300, validate_certs=True,
             url_username=None, url_password=None, http_agent=None, force_basic_auth=True, ignore_errors=False):

--- a/test_firewall_section_with_rules.yml
+++ b/test_firewall_section_with_rules.yml
@@ -1,0 +1,27 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  become: yes
+  vars_files:
+    - answerfile.yml
+    - answerfile_firewall.yml
+  tasks:
+    - name: Create DFW Section with Rules
+      nsxt_firewall_section_with_rules:
+        hostname: "{{ hostname }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        applied_tos: "{{ item.applied_tos | default([]) }}"
+        display_name: "{{ item.display_name }}"
+        description: "{{ item.description | default(omit) }}"
+        modify_placement: "{{ item.modify_placement | default(omit) }}"
+        rules: "{{ item.rules | default([]) }}"
+        section_placement: "{{ item.section_placement | default(omit) }}"
+        section_type: LAYER3
+        state: "{{ item.state }}"
+        stateful: "{{ item.stateful | default(True) }}"
+        tags: "{{ item.tags | default([]) }}"
+        validate_certs: False
+      with_items:
+        - "{{ nsxt_dfw_section_with_rules }}"
+

--- a/test_firewall_section_with_rules.yml
+++ b/test_firewall_section_with_rules.yml
@@ -1,11 +1,93 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  become: yes
   vars_files:
     - answerfile.yml
     - answerfile_firewall.yml
   tasks:
+    - name: Create a new IP Set
+      nsxt_ip_sets:
+        hostname: "{{ hostname }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        display_name: "{{ item.display_name }}"
+        ip_addresses: "{{ item.ip_addresses }}"
+        state: "{{ item.state }}"
+        validate_certs: False
+      with_items:
+        - "{{ nsxt_ip_sets }}"
+
+    - name: Create a new NS Group
+      nsxt_ns_groups:
+        hostname: "{{ hostname }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        display_name: "{{ item.display_name }}"
+        members: "{{ item.members | default([]) }}"
+        membership_criteria: "{{ item.membership_criteria | default([]) }}"
+        resource_type: "NSGroup"
+        state: "{{ item.state }}"
+        validate_certs: False
+      with_items:
+        - "{{ nsxt_ns_groups }}"
+
+    - name: Create transport zone
+      nsxt_transport_zones:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        resource_type: "TransportZone"
+        display_name: "tz-fw-testing"
+        description: "NSX configured Test Transport Zone"
+        transport_type: "OVERLAY"
+        host_switch_name: "sw-fw-testing"
+        state: "present"
+
+    - name: Create logical switch
+      nsxt_logical_switches:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "ls-fw-testing"
+        replication_mode: SOURCE
+        transport_zone_name: "tz-fw-testing"
+        admin_state: "UP"
+        state: "present"
+
+    - name: Create a Logical Port
+      nsxt_logical_ports:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "lp-fw-testing"
+        logical_switch_name: "ls-fw-testing"
+        admin_state: "UP"
+        state: "present"
+
+    - name: Create logical router
+      nsxt_logical_routers:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "t1-fw-testing"
+        router_type: "TIER1"
+        state: "present"
+
+    - name: Create logical router port
+      nsxt_logical_router_ports:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "lrp-fw-testing"
+        resource_type: "LogicalRouterLinkPortOnTIER1"
+        logical_router_name: "t1-fw-testing"
+        state: "present"
+
     - name: Create DFW Section with Rules
       nsxt_firewall_section_with_rules:
         hostname: "{{ hostname }}"

--- a/test_firewall_section_with_rules_tidy_up.yml
+++ b/test_firewall_section_with_rules_tidy_up.yml
@@ -1,0 +1,108 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  vars_files:
+    - answerfile.yml
+    - answerfile_firewall.yml
+  tasks:
+    - name: Delete DFW Section with Rules
+      nsxt_firewall_section_with_rules:
+        hostname: "{{ hostname }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        applied_tos: "{{ item.applied_tos | default([]) }}"
+        display_name: "{{ item.display_name }}"
+        description: "{{ item.description | default(omit) }}"
+        modify_placement: "{{ item.modify_placement | default(omit) }}"
+        rules: "{{ item.rules | default([]) }}"
+        section_placement: "{{ item.section_placement | default(omit) }}"
+        section_type: LAYER3
+        state: "absent"
+        stateful: "{{ item.stateful | default(True) }}"
+        tags: "{{ item.tags | default([]) }}"
+        validate_certs: False
+      with_items:
+        - "{{ nsxt_dfw_section_with_rules }}"
+
+    - name: Delete a new NS Group
+      nsxt_ns_groups:
+        hostname: "{{ hostname }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        display_name: "{{ item.display_name }}"
+        members: "{{ item.members | default([]) }}"
+        membership_criteria: "{{ item.membership_criteria | default([]) }}"
+        resource_type: "NSGroup"
+        state: "absent"
+        validate_certs: False
+      with_items:
+        - "{{ nsxt_ns_groups }}"
+
+    - name: Delete a new IP Set
+      nsxt_ip_sets:
+        hostname: "{{ hostname }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        display_name: "{{ item.display_name }}"
+        ip_addresses: "{{ item.ip_addresses }}"
+        state: "absent"
+        validate_certs: False
+      with_items:
+        - "{{ nsxt_ip_sets }}"
+
+    - name: Delete a Logical Port
+      nsxt_logical_ports:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "lp-fw-testing"
+        logical_switch_name: "ls-fw-testing"
+        admin_state: "UP"
+        state: "absent"
+
+    - name: Delete logical switch
+      nsxt_logical_switches:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "ls-fw-testing"
+        replication_mode: SOURCE
+        transport_zone_name: "tz-fw-testing"
+        admin_state: "UP"
+        state: "absent"
+
+    - name: Delete transport zone
+      nsxt_transport_zones:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        resource_type: "TransportZone"
+        display_name: "tz-fw-testing"
+        description: "NSX configured Test Transport Zone"
+        transport_type: "OVERLAY"
+        host_switch_name: "sw-fw-testing"
+        state: "absent"
+
+    - name: Delete logical router port
+      nsxt_logical_router_ports:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "lrp-fw-testing"
+        resource_type: "LogicalRouterLinkPortOnTIER1"
+        logical_router_name: "t1-fw-testing"
+        state: "absent"
+
+    - name: Delete logical router
+      nsxt_logical_routers:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "t1-fw-testing"
+        router_type: "TIER1"
+        state: "absent"

--- a/test_ip_sets.yml
+++ b/test_ip_sets.yml
@@ -1,8 +1,8 @@
 - hosts: 127.0.0.1
   connection: local
-  become: yes
   vars_files:
     - answerfile.yml
+    - answerfile_firewall.yml
   tasks:
     - name: Create a new IP Set
       nsxt_ip_sets:

--- a/test_ip_sets.yml
+++ b/test_ip_sets.yml
@@ -1,0 +1,17 @@
+- hosts: 127.0.0.1
+  connection: local
+  become: yes
+  vars_files:
+    - answerfile.yml
+  tasks:
+    - name: Create a new IP Set
+      nsxt_ip_sets:
+        hostname: "{{ hostname }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        display_name: "{{ item.display_name }}"
+        ip_addresses: "{{ item.ip_addresses }}"
+        state: "{{ item.state }}"
+        validate_certs: False
+      with_items:
+        - "{{ nsxt_ip_sets }}"

--- a/test_ns_group.yml
+++ b/test_ns_group.yml
@@ -1,0 +1,19 @@
+- hosts: 127.0.0.1
+  connection: local
+  become: yes
+  vars_files:
+    - answerfile.yml
+  tasks:
+    - name: Create a new NS Group
+      nsxt_ns_groups:
+        hostname: "{{ hostname }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        display_name: "{{ item.display_name }}"
+        members: "{{ item.members | default([]) }}"
+        membership_criteria: "{{ item.membership_criteria | default([]) }}"
+        resource_type: "NSGroup"
+        state: "{{ item.state }}"
+        validate_certs: False
+      with_items:
+        - "{{ nsxt_ns_groups }}"

--- a/test_ns_groups.yml
+++ b/test_ns_groups.yml
@@ -1,8 +1,8 @@
 - hosts: 127.0.0.1
   connection: local
-  become: yes
   vars_files:
     - answerfile.yml
+    - answerfile_firewall.yml
   tasks:
     - name: Create a new NS Group
       nsxt_ns_groups:

--- a/test_services.yml
+++ b/test_services.yml
@@ -1,0 +1,21 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  become: yes
+  vars_files:
+    - answerfile.yml
+    - answerfile_firewall.yml
+  tasks:
+    - name: Create ip pool
+      nsxt_services:
+        hostname: "{{hostname}}"
+        username: "{{username}}"
+        password: "{{password}}"
+        validate_certs: False
+        display_name: "{{ item.display_name }}"
+        description: "{{ item.description | default(omit) }}"
+        nsservice_element: "{{ item.nsservice_element }}"
+        tags: "{{ item.tags | default([]) }}"
+        state: present
+      with_items:
+        - "{{services}}"

--- a/test_services.yml
+++ b/test_services.yml
@@ -1,12 +1,11 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  become: yes
   vars_files:
     - answerfile.yml
     - answerfile_firewall.yml
   tasks:
-    - name: Create ip pool
+    - name: Create Service
       nsxt_services:
         hostname: "{{hostname}}"
         username: "{{username}}"


### PR DESCRIPTION
Added modules to cover creation of layer-3 firewall section with rules, ip sets, ns groups and services.

Modules have been fully implemented to API spec and have been tested to be idempotent. Code handles there being objects with duplicate names and aborts if they are used and handles the API returning cursors on API requests. Module will place rules within a section and modify placement during update if placement has changed and the modify flag is set.

The comparison operations vary depending on data structures. Implemented with mixture of comparing hashes of concatenated lists strings, list comprehension to compare values is keys exist and direct comparison.

Added support for api pagination to module_utils/vmware_nsxt.py. 'request_get_all' is a drop in replacement for 'request' when performing a get, but will handle api pagination.
Also fixed a couple of python 2>3 bugs which didn't appear before.


Signed-off-by: Matt Proud proudmatt@gmail.com