### PR TITLE
Make urpf_mode optional to be compatible with 2.5.1

### DIFF
--- a/library/nsxt_policy_tier0.py
+++ b/library/nsxt_policy_tier0.py
@@ -1146,12 +1146,13 @@ options:
                                 type: bool
                                 default: False
                     urpf_mode:
-                        description: Unicast Reverse Path Forwarding mode
+                        description:
+                            - Unicast Reverse Path Forwarding mode
+                            - Required if NSXT API >= 3.0.0. Defaults to STRICT
                         type: str
                         choices:
                             - NONE
                             - STRICT
-                        default: STRICT
                     create_or_update_subresource_first:
                         type: bool
                         default: false
@@ -1967,7 +1968,6 @@ class NSXTTier0(NSXTBaseRealizableResource):
                     ),
                     urpf_mode=dict(
                         type='str',
-                        default='STRICT',
                         choices=['NONE', 'STRICT']
                     )
                 )

--- a/library/nsxt_policy_tier1.py
+++ b/library/nsxt_policy_tier1.py
@@ -803,12 +803,13 @@ options:
                                 description: Subnet prefix length
                                 type: str
                     urpf_mode:
-                        description: Unicast Reverse Path Forwarding mode
+                        description:
+                            - Unicast Reverse Path Forwarding mode
+                            - Required if NSXT API >= 3.0.0. Defaults to STRICT
                         type: str
                         choices:
                             - NONE
                             - STRICT
-                        default: STRICT
 '''
 
 EXAMPLES = '''
@@ -1377,7 +1378,6 @@ class NSXTTier1(NSXTBaseRealizableResource):
                     ),
                     urpf_mode=dict(
                         type='str',
-                        default='STRICT',
                         choices=['NONE', 'STRICT']
                     )
                 )


### PR DESCRIPTION
urpf_mode is in Tier0 and Tier1 LocaleService -> Interfaces

Issue: #2592531

Signed-off-by: Gautam Verma <vermag@vmware.com>
Signed-off-by: Gautam Verma <gautam94verma@gmail.com>