### PR TITLE
Remove empty params for req body

### DIFF
--- a/library/nsxt_policy_segment.py
+++ b/library/nsxt_policy_segment.py
@@ -883,14 +883,13 @@ class NSXTSegment(NSXTBaseRealizableResource):
         if 'advanced_config' in nsx_resource_params and nsx_resource_params[
                 'advanced_config']:
             address_pool_id = None
-            if nsx_resource_params['advanced_config'][
-                    'address_pool_id']:
+            if nsx_resource_params['advanced_config'].get('address_pool_id'):
                 address_pool_id = nsx_resource_params['advanced_config'].pop(
                     'address_pool_id')
                 nsx_resource_params['advanced_config'].pop(
                     'address_pool_display_name')
-            elif nsx_resource_params['advanced_config'][
-                    'address_pool_display_name']:
+            elif nsx_resource_params['advanced_config'].get(
+                    'address_pool_display_name'):
                 address_pool_id = self.get_id_from_display_name(
                     IP_POOL_URL, nsx_resource_params['advanced_config'][
                         'address_pool_display_name'], "Ip Pool",
@@ -899,11 +898,6 @@ class NSXTSegment(NSXTBaseRealizableResource):
                     'address_pool_display_name')
                 nsx_resource_params['advanced_config'].pop(
                     'address_pool_id')
-            else:
-                nsx_resource_params['advanced_config'].pop(
-                    'address_pool_id')
-                nsx_resource_params['advanced_config'].pop(
-                    'address_pool_display_name')
             if address_pool_id:
                 address_pool_paths = [IP_POOL_URL + "/" + address_pool_id]
                 nsx_resource_params['advanced_config'][

--- a/module_utils/nsxt_base_resource.py
+++ b/module_utils/nsxt_base_resource.py
@@ -125,6 +125,9 @@ class NSXTBaseRealizableResource(ABC):
         except Exception as err:
             # the resource does not exist currently on the manager
             self.existing_resource = None
+        finally:
+            self._clean_none_resource_params(
+                self.existing_resource, self.nsx_resource_params)
         self._achieve_state(resource_params, successful_resource_exec_logs)
 
     @classmethod
@@ -822,3 +825,15 @@ class NSXTBaseRealizableResource(ABC):
                 resource_params[k] = v
             elif type(v).__name__ == 'dict':
                 self._fill_missing_resource_params(v, resource_params[k])
+
+    def _clean_none_resource_params(self, existing_params, resource_params):
+        keys_to_remove = []
+        for k, v in resource_params.items():
+            if v is None and (
+                    existing_params is None or k not in existing_params):
+                keys_to_remove.append(k)
+        for key in keys_to_remove:
+            resource_params.pop(key)
+        for k, v in resource_params.items():
+            if type(v).__name__ == 'dict':
+                self._clean_none_resource_params(existing_params, v)


### PR DESCRIPTION
We should remove empty params from request body while making PATCH
call if the same attrs are not set already on the resource.
Otherwise, we assume that there is a PATCH operation
being done on it while in reality, there is None.

Eg. Policy API returns a response in which None attrs are not set.
When we create the user request body, we set attrs to None. Although
both mean semantically the same, the syntax difference makes us
assume that a PATCH call should be done

Issue: #317