### PR TITLE
Verify resource was updated after PATCH

### DIFF
--- a/module_utils/nsxt_base_resource.py
+++ b/module_utils/nsxt_base_resource.py
@@ -117,6 +117,8 @@ class NSXTBaseRealizableResource(ABC):
             _, self.existing_resource = self._send_request_to_API(
                 "/" + self.id, ignore_error=False,
                 accepted_error_codes=set([404]))
+            self.existing_resource_revision = self.existing_resource[
+                '_revision']
             # As Policy API's PATCH requires all attributes to be filled,
             # we fill the missing resource params (the params not specified)
             # by user using the existing params
@@ -125,6 +127,7 @@ class NSXTBaseRealizableResource(ABC):
         except Exception as err:
             # the resource does not exist currently on the manager
             self.existing_resource = None
+            self.existing_resource_revision = None
         finally:
             self._clean_none_resource_params(
                 self.existing_resource, self.nsx_resource_params)
@@ -612,17 +615,30 @@ class NSXTBaseRealizableResource(ABC):
             self.nsx_resource_params['_revision'] = \
                 self.existing_resource['_revision']
             try:
-                _, resp = self._send_request_to_API(
+                _, patch_resp = self._send_request_to_API(
                     suffix="/"+self.id, method="PATCH",
                     data=self.nsx_resource_params)
-                successful_resource_exec_logs.append({
-                    "changed": True,
-                    "id": self.id,
-                    "body": str(resp),
-                    "message": "%s with id %s updated." %
-                    (self.get_resource_name(), self.id),
-                    "resource_type": self.get_resource_name()
-                })
+                # Get the resource again and compare version numbers
+                _, updated_resource_spec = self._send_request_to_API(
+                    suffix="/"+self.id, method="GET")
+                if updated_resource_spec[
+                        '_revision'] != self.existing_resource_revision:
+                    successful_resource_exec_logs.append({
+                        "changed": True,
+                        "id": self.id,
+                        "body": str(patch_resp),
+                        "message": "%s with id %s updated." %
+                        (self.get_resource_name(), self.id),
+                        "resource_type": self.get_resource_name()
+                    })
+                else:
+                    successful_resource_exec_logs.append({
+                        "changed": False,
+                        "id": self.id,
+                        "message": "%s with id %s already exists." %
+                        (self.get_resource_name(), self.id),
+                        "resource_type": self.get_resource_name()
+                    })
             except Exception as err:
                 srel = successful_resource_exec_logs
                 self.module.fail_json(msg="Failed to update %s with id %s."


### PR DESCRIPTION
In some cases, it is not possible to infer if a PATCH call should
be made on the NSX-t resource. This is because Ansible substitues
missing keys with None. We always send the PATCH call in such cases.
If the server updates the resource, it's revision is updated and
we check it to infer if it was updated actually.

Issue: #2658008

Signed-off-by: Gautam Verma <vermag@vmware.com>
Signed-off-by: Gautam Verma <gautam94verma@gmail.com>