### PR TITLE
Fix invalid key error in policy segment

### DIFF
--- a/library/nsxt_policy_segment.py
+++ b/library/nsxt_policy_segment.py
@@ -886,8 +886,6 @@ class NSXTSegment(NSXTBaseRealizableResource):
             if nsx_resource_params['advanced_config'].get('address_pool_id'):
                 address_pool_id = nsx_resource_params['advanced_config'].pop(
                     'address_pool_id')
-                nsx_resource_params['advanced_config'].pop(
-                    'address_pool_display_name')
             elif nsx_resource_params['advanced_config'].get(
                     'address_pool_display_name'):
                 address_pool_id = self.get_id_from_display_name(
@@ -896,8 +894,6 @@ class NSXTSegment(NSXTBaseRealizableResource):
                     ignore_not_found_error=False)
                 nsx_resource_params['advanced_config'].pop(
                     'address_pool_display_name')
-                nsx_resource_params['advanced_config'].pop(
-                    'address_pool_id')
             if address_pool_id:
                 address_pool_paths = [IP_POOL_URL + "/" + address_pool_id]
                 nsx_resource_params['advanced_config'][


### PR DESCRIPTION
It is raised when one of address_pool_id or address_pool_display_name
is specified. With patch 054d5b1, we don't need the instructions that
remove the other key from request body which is not specified.

Issue: #2667627

Signed-off-by: Gautam Verma <vermag@vmware.com>
Signed-off-by: Gautam Verma <gautam94verma@gmail.com>