### PR TITLE
Infer LocaleService ID automatically if precreated

### DIFF
--- a/library/nsxt_policy_tier0.py
+++ b/library/nsxt_policy_tier0.py
@@ -1683,6 +1683,25 @@ class NSXTTier0(NSXTBaseRealizableResource):
         def get_spec_identifier(cls):
             return "locale_services"
 
+        def infer_resource_id(self, parent_info):
+            all_locale_services = self.get_all_resources_from_nsx()
+            if len(all_locale_services) == 0:
+                self.module.fail_json(
+                    msg="No {} found under Tier0 gateway {}. Please specify "
+                        "the id or display_name of the LocaleService to be "
+                        "created".format(
+                            self.get_spec_identifier(),
+                            parent_info.get("tier0_id", 'default')))
+            if len(all_locale_services) > 1:
+                ls_ids = [ls['id'] for ls in all_locale_services]
+                self.module.fail_json(
+                    msg="Multiple {} found under Tier0 gateway {} with IDs "
+                        "{}. Please specify the id of the LocaleService "
+                        "to be updated".format(
+                            self.get_spec_identifier(),
+                            parent_info.get("tier0_id", 'default'), ls_ids))
+            return all_locale_services[0]['id']
+
         @staticmethod
         def get_resource_spec():
             tier0_ls_arg_spec = {}

--- a/library/nsxt_policy_tier1.py
+++ b/library/nsxt_policy_tier1.py
@@ -1110,6 +1110,25 @@ class NSXTTier1(NSXTBaseRealizableResource):
         def get_spec_identifier(cls):
             return "locale_services"
 
+        def infer_resource_id(self, parent_info):
+            all_locale_services = self.get_all_resources_from_nsx()
+            if len(all_locale_services) == 0:
+                self.module.fail_json(
+                    msg="No {} found under Tier1 gateway {}. Please specify "
+                        "the id or display_name of the LocaleService to be "
+                        "created".format(
+                            self.get_spec_identifier(),
+                            parent_info.get("tier1_id", 'default')))
+            if len(all_locale_services) > 1:
+                ls_ids = [ls['id'] for ls in all_locale_services]
+                self.module.fail_json(
+                    msg="Multiple {} found under Tier1 gateway {} with IDs "
+                        "{}. Please specify the id of the LocaleService "
+                        "to be updated".format(
+                            self.get_spec_identifier(),
+                            parent_info.get("tier1_id", 'default'), ls_ids))
+            return all_locale_services[0]['id']
+
         @staticmethod
         def get_resource_spec():
             tier1_ls_arg_spec = {}


### PR DESCRIPTION
LocaleService is automatically created by NSX when the user tries
to do some operation on tier0/1 like set the Edge Cluster. In such cases,
the ID cannot be known by the user as they only have access to UI.
Therefore, if it cannot be specified we use the existing LocaleService
on the gateway and configure that.

If no LocaleService was present but user didn't specify ID or display_name,
then error is thrown to provide either of them

If multiple LocaleServices are present, error is thrown to specify the exact
LocaleService ID.

Issue: #2655611