### PR TITLE
Small changes regarding T1 routing advertisement and Segment TZ

### DIFF
--- a/examples/policy_modules/build_topology_vars.yml
+++ b/examples/policy_modules/build_topology_vars.yml
@@ -66,7 +66,7 @@
         {
             "display_name": "Web-Segment",
             "tier1_display_name": "Tier-1",
-            "tz": "Overlay-TZ",
+            "tz": "nsx-overlay-transportzone",
             "domain_name": "mylab.net",
             "subnets": [
                 {
@@ -87,7 +87,7 @@
         {
             "display_name": "App-Segment",
             "tier1_display_name": "Tier-1",
-            "tz": "Overlay-TZ",
+            "tz": "nsx-overlay-transportzone",
             "domain_name": "mylab.net",
             "subnets": [
                 {
@@ -108,7 +108,7 @@
         {
             "display_name": "DB-Segment",
             "tier1_display_name": "Tier-1",
-            "tz": "Overlay-TZ",
+            "tz": "nsx-overlay-transportzone",
             "domain_name": "mylab.net",
             "subnets": [
                 {


### PR DESCRIPTION
adding the "route_advertisement_types": [ "TIER1_CONNECTED", "TIER1_NAT" ], in the script can speedup the T1 routing configuraton

changing the transport zone from "tz": "Overlay-TZ" to "tz": "nsx-overlay-transportzone" helps in NSX 3.x environemnt as it's the default setting