### PR TITLE
Added example for manual cluster deployment

### DIFF
--- a/examples/deploy_nsx_cluster_manually/01_deploy_manager_nodes.yml
+++ b/examples/deploy_nsx_cluster_manually/01_deploy_manager_nodes.yml
@@ -1,0 +1,48 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause OR GPL-3.0-only
+---
+#
+# Playbook to deploy the all three NSX Appliance nodes via ovftool. This is useful if unable to deploy using automated method.
+#
+- hosts: 127.0.0.1
+  connection: local
+  vars_files:
+    - deploy_nsx_cluster_manually_vars.yml
+  tasks:
+  - name: deploy NSX Manager OVA
+    nsxt_deploy_ova:
+      datacenter: "{{ item.datacenter }}"
+      datastore: "{{ item.datastore }}"
+      portgroup: "{{ item.portgroup }}"
+      cluster: "{{ item.cluster }}"
+      vmname: "{{ item.hostname }}"
+      hostname: "{{ item.hostname }}"
+      dns_server: "{{ dns_server }}"
+      dns_domain: "{{ domain }}"
+      ntp_server: "{{ ntp_server }}"
+      gateway: "{{ gateway }}"
+      ip_address: "{{ item.mgmt_ip }}"
+      netmask: "{{ netmask }}"
+      admin_password: "{{ nsx_password }}"
+      cli_password: "{{ nsx_password }}"
+      ovftool_path: "{{ ovftool_path }}"
+      path_to_ova: "{{ nsx_ova_path }}"
+      ova_file: "{{ nsx_ova }}"
+      vcenter: "{{ mgmt_vcenter[0]['mgmt_ip'] }}"
+      vcenter_user: "{{ mgmt_vcenter[0]['username'] }}"
+      vcenter_passwd: "{{ mgmt_vcenter[0]['password'] }}"
+      deployment_size: "small"
+      role: "NSX Manager"
+      allow_ssh_root_login: "{{ allow_ssh_root_login }}"
+      ssh_enabled: "{{ ssh_enabled }}"
+    with_items:
+        - "{{ nodes }}"
+  - name: Check manager status
+    nsxt_manager_status:
+      hostname: "{{ item.hostname }}"
+      username: "{{ nsx_username }}"
+      password: "{{ nsx_password }}"
+      validate_certs: 'false'
+      wait_time: 50
+    with_items:
+        - "{{ nodes }}"

--- a/examples/deploy_nsx_cluster_manually/02_join_nodes_to_cluster.yml
+++ b/examples/deploy_nsx_cluster_manually/02_join_nodes_to_cluster.yml
@@ -1,0 +1,55 @@
+# Copyright 2021 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause OR GPL-3.0-only
+---
+#
+# Playbook to join the 2nd and 3rd Manager nodes to the cluster using ansible.builtin.uri module. This is useful if unable to deploy using automated method.
+#
+- hosts: 127.0.0.1
+  connection: local
+  vars_files:
+    - deploy_nsx_cluster_manually_vars.yml
+  tasks:
+  - name: get cluster id
+    ansible.builtin.uri:
+      method: GET
+      url: https://{{ nodes[0]['hostname'] }}/api/v1/cluster
+      force_basic_auth: yes
+      user: "{{ nsx_username }}"
+      password: "{{ nsx_password }}"
+      validate_certs: false
+    register: cluster_id
+  - name: get thumbprint
+    ansible.builtin.uri:
+      method: GET
+      url: https://{{ nodes[0]['hostname'] }}/api/v1/search/query?query=resource_type:ClusterNodeConfig%20%26%26%20appliance_mgmt_listen_addr:{{ nodes[0]['mgmt_ip'] }}
+      force_basic_auth: yes
+      user: "{{ nsx_username }}"
+      password: "{{ nsx_password }}"
+      validate_certs: false
+    register: thumbprint
+  - name: Set the Facts
+    set_fact:
+      id: "{{ cluster_id['json']['cluster_id'] }}"
+      thumb: "{{ thumbprint['json']['results'][0]['manager_role']['api_listen_addr']['certificate_sha256_thumbprint'] }}"
+  - name: Join to cluster
+    ansible.builtin.uri:
+      method: POST
+      url: https://{{ nodes[1]['hostname'] }}/api/v1/cluster?action=join_cluster
+      force_basic_auth: yes
+      user: "{{ nsx_username }}"
+      password: "{{ nsx_password }}"
+      validate_certs: false
+      timeout: 180
+      body_format: json
+      body:
+        {
+          "cluster_id": "{{ id }}",
+          "ip_address": "{{ nodes[0]['mgmt_ip'] }}",
+          "username": "{{ nsx_username }}",
+          "password": "{{ nsx_password }}",
+          "certficate_sha256_thumbprint": "{{ thumb }}"
+        }
+    register: cluster_id
+    with_items:
+        - nodes[1]
+        - nodes[2]

--- a/examples/deploy_nsx_cluster_manually/deploy_nsx_cluster_manually_vars.yml
+++ b/examples/deploy_nsx_cluster_manually/deploy_nsx_cluster_manually_vars.yml
@@ -1,0 +1,43 @@
+  ovftool_path: "/Applications/VMware OVF Tool"
+  nsx_ova_path: ./software
+  nsx_ova: nsx-unified-appliance-3.1.1.0.0.17483186.ova
+  
+  mgmt_vcenter:
+  - display_name: vcenter
+    mgmt_ip: vc.mylab.local
+    origin_type: vCenter
+    credential_type: UsernamePasswordLoginCredential
+    username: administrator@vsphere.local
+    password: VMware1!
+    state: present
+  
+  nsx_username: admin
+  nsx_password: VMware1!VMware1!
+  validate_certs: 'false'
+  allow_ssh_root_login: 'False'
+  ssh_enabled: 'True'
+  domain: mylab.local
+  netmask: 255.255.255.0
+  gateway: 192.168.10.1
+  dns_server: 10.116.1.201
+  ntp_server: time.mylab.local
+
+  nodes:
+    - hostname: nsxt1.mylab.local
+      mgmt_ip: 192.168.10.31
+      datacenter: Datacenter
+      cluster: Cluster
+      datastore: NFS
+      portgroup: Lab
+    - hostname: nsxt2.mylab.local
+      mgmt_ip: 192.168.10.32
+      datacenter: Datacenter
+      cluster: Cluster
+      datastore: NFS
+      portgroup: Lab
+    - hostname: nsxt3.mylab.local
+      mgmt_ip: 192.168.10.33
+      datacenter: Datacenter
+      cluster: Cluster
+      datastore: NFS
+      portgroup: Lab


### PR DESCRIPTION
Added example playbooks to demonstrate how to deploy a 3-node cluster manually - without the use of NSX-T Manager deploying the 2nd and 3rd nodes.  This is useful for customers who need to deploy the 3 nodes and join them manually.  An example reason would be if NSX-T Manager cannot connect to a Compute Manager to deploy the 2nd/3rd nodes.

Signed-off-by: Andy Schneider <andyjohnschneider@gmail.com>