### PR TITLE
Adding CA validation in MP modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ the file nsx_certificate.p12 file contains the public and private key generated.
 
 Note: usr_cert tells OpenSSL to generate a client certificate. This must be defined in openssl.cnf.
 
+#### Validate CA in MP API
+
+To validate ceritificate authority (CA), set NSX_MANAGER_CA_PATH environment variable on Ansible control node pointing to CA certificate of NSX manager and pass validate_certs as ``True`` in ansible playbook.
+
 #### Using Policy API
 All the Policy API based Ansible Modules provide the following authentication mechanisms:
 

--- a/module_utils/vmware_nsxt.py
+++ b/module_utils/vmware_nsxt.py
@@ -42,11 +42,13 @@ def request(url, data=None, headers=None, method='GET', use_proxy=True,
     else:
         client_cert = None
 
+    ca_path = get_certificate_file_path('NSX_MANAGER_CA_PATH')
+
     try:
         r = open_url(url=url, data=data, headers=headers, method=method, use_proxy=use_proxy,
                      force=force, last_mod_time=last_mod_time, timeout=timeout, validate_certs=validate_certs,
                      url_username=url_username, url_password=url_password, http_agent=http_agent,
-                     client_cert=client_cert, force_basic_auth=force_basic_auth)
+                     client_cert=client_cert, force_basic_auth=force_basic_auth, ca_path=ca_path)
     except HTTPError as err:
         r = err
 


### PR DESCRIPTION
To validate ceritificate authority (CA), set NSX_MANAGER_CA_PATH environment variable on Ansible control node pointing to CA certificate of NSX manager and pass validate_certs as True in ansible playbook.

bug#2747064
Signed-off-by:  Rahul Raghuvanshi <rraghuvanshi@vmware.com>