### PR TITLE
Fix inferring res ID from display_name

### DIFF
--- a/plugins/module_utils/nsxt_base_resource.py
+++ b/plugins/module_utils/nsxt_base_resource.py
@@ -398,7 +398,7 @@ class NSXTBaseRealizableResource(ABC):
             (_, resp) = self._send_request_to_API(
                 resource_base_url=resource_base_url)
             matched_resource = None
-            for resource in resp['results']:
+            for resource in resp:
                 if (resource.__contains__('display_name') and
                         resource['display_name'] == resource_display_name):
                     if matched_resource is None:
@@ -735,7 +735,7 @@ class NSXTBaseRealizableResource(ABC):
             self.module.fail_json(
                 "Invalid URL to retrieve all configured {} NSX "
                 "resources".format(self.get_spec_identifier()))
-        return resp['results']
+        return resp
 
     def _achieve_state(self, resource_params,
                        successful_resource_exec_logs=[]):

--- a/plugins/modules/nsxt_policy_segment.py
+++ b/plugins/modules/nsxt_policy_segment.py
@@ -1130,7 +1130,7 @@ class NSXTSegment(NSXTBaseRealizableResource):
         self._updateSubnetsAsPerIpvType(nsx_resource_params)
 
     def _updateSubnetsAsPerIpvType(self, nsx_resource_params):
-        subnets = nsx_resource_params['subnets']
+        subnets = nsx_resource_params.get('subnets', [])
         for subnet in subnets:
             dhcp_config = subnet.get('dhcp_config')
             if dhcp_config:


### PR DESCRIPTION
With the last update to fetch all the resources from NSX accounting
for pagination, the logic to infer ID from display_name of a resource
specified in the Ansible spec broke. This patch fixes it

Issue: #371

Signed-off-by: Gautam Verma <vermag@vmware.com>
Signed-off-by: Gautam Verma <gautam94verma@gmail.com>