### PR TITLE
Fix: add check to only update subnet if defined

### DIFF
--- a/plugins/modules/nsxt_policy_segment.py
+++ b/plugins/modules/nsxt_policy_segment.py
@@ -1127,7 +1127,8 @@ class NSXTSegment(NSXTBaseRealizableResource):
                 nsx_resource_params['advanced_config'][
                     'address_pool_paths'] = address_pool_paths
 
-        self._updateSubnetsAsPerIpvType(nsx_resource_params)
+        if nsx_resource_params.__contains__('subnets'):
+            self._updateSubnetsAsPerIpvType(nsx_resource_params)
 
     def _updateSubnetsAsPerIpvType(self, nsx_resource_params):
         subnets = nsx_resource_params['subnets']


### PR DESCRIPTION
Reference https://github.com/vmware/ansible-for-nsxt/issues/372

This fix ensure that a segment contains the subnets key before trying to modify subnet dhcp config.

This allows for segment without subnets to be used for things such as the T0 unlink network.

Signed-off-by: Matt Proud <proudmatt@gmail.com>