### PR TITLE
Multiple Bug Fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ The following versions of NSX are supported:
  * NSX-T 3.0
  * NSX-T 2.5.1
 
-//
-
 ## Prerequisites
 
 Using Ansible-for-nsxt requires the following packages to be installated. Installation steps differ based on the platform (Mac/iOS, Ubuntu, Debian, CentOS, RHEL etc). Please follow the links below to pick the right platform.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The following versions of NSX are supported:
  * NSX-T 3.0
  * NSX-T 2.5.1
 
+//
+
 ## Prerequisites
 
 Using Ansible-for-nsxt requires the following packages to be installated. Installation steps differ based on the platform (Mac/iOS, Ubuntu, Debian, CentOS, RHEL etc). Please follow the links below to pick the right platform.

--- a/plugins/modules/nsxt_transport_node_collections.py
+++ b/plugins/modules/nsxt_transport_node_collections.py
@@ -19,7 +19,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-
 DOCUMENTATION = '''
 ---
 module: nsxt_transport_node_collections
@@ -192,7 +191,27 @@ def check_for_update(module, manager_url, mgr_username, mgr_password, validate_c
     if existing_tnc is None:
         return False
     if existing_tnc['compute_collection_id'] == transport_node_collection_with_ids['compute_collection_id'] and \
-        existing_tnc['transport_node_profile_id'] != transport_node_collection_with_ids['transport_node_profile_id']:
+            existing_tnc['transport_node_profile_id'] != \
+            transport_node_collection_with_ids['transport_node_profile_id']:
+        return True
+    if existing_tnc.__contains__('description') and not transport_node_collection_with_ids.__contains__('description'):
+        return True
+    if not existing_tnc.__contains__('description') and transport_node_collection_with_ids.__contains__('description'):
+        return True
+    if existing_tnc.__contains__('description') and transport_node_collection_with_ids.__contains__('description') and \
+            existing_tnc['description'] != transport_node_collection_with_ids['description']:
+        return True
+    if existing_tnc.__contains__('transport_node_profile_name') and \
+            transport_node_collection_with_ids.__contains__('transport_node_profile_name') \
+            and existing_tnc['transport_node_profile_name'] != \
+            transport_node_collection_with_ids['transport_node_profile_name']:
+        return True
+    if existing_tnc.__contains__('tags') and not transport_node_collection_with_ids.__contains__('tags'):
+        return True
+    if not existing_tnc.__contains__('tags') and transport_node_collection_with_ids.__contains__('tags'):
+        return True
+    if existing_tnc.__contains__('tags') and transport_node_collection_with_ids.__contains__('tags') and \
+            (not compareTags(existing_tnc, transport_node_collection_with_ids)):
         return True
     return False
 
@@ -271,6 +290,19 @@ def main():
     wait_till_delete(id, module, manager_url, mgr_username, mgr_password, validate_certs)
 
     module.exit_json(changed=True, id=id, message="transport-node-collection with name %s deleted." % display_name)
+
+
+def compareTags(existing_tnc, new_tnc):
+    return ordered(existing_tnc['tags']) == ordered(new_tnc['tags'])
+
+
+def ordered(obj):
+    if isinstance(obj, dict):
+        return sorted((k, ordered(v)) for k, v in obj.items())
+    if isinstance(obj, list):
+        return sorted(ordered(x) for x in obj)
+    else:
+        return obj
 
 
 if __name__ == '__main__':

--- a/plugins/modules/nsxt_transport_zones.py
+++ b/plugins/modules/nsxt_transport_zones.py
@@ -26,10 +26,7 @@ module: nsxt_transport_zones
 short_description: Create a Transport Zone
 description: Creates a new transport zone. The required parameters are host_switch_name
 and transport_type (OVERLAY or VLAN). The optional parameters are
-description and display_name. This api is now deprecated. Please use new api - 
-PUT /infra/sites/<site-id>/enforcement-points/<enforcementpoint- 
-id>/transport-zones/<zone-id>
-
+description and display_name.
 
 version_added: "2.7"
 author: Rahul Raghuvanshi

--- a/plugins/modules/nsxt_uplink_profiles.py
+++ b/plugins/modules/nsxt_uplink_profiles.py
@@ -226,6 +226,10 @@ def check_for_update(module, manager_url, mgr_username, mgr_password, validate_c
     if existing_profile.__contains__('transport_vlan') and profile_params.__contains__('transport_vlan') and \
         existing_profile['transport_vlan'] != profile_params['transport_vlan']:
         return True
+    if existing_profile.__contains__('lags') and not profile_params.__contains__('lags'):
+        return True
+    if not existing_profile.__contains__('lags') and profile_params.__contains__('lags'):
+        return True
     if profile_params.__contains__('lags') and profile_params['lags']:
        existing_lags = existing_profile['lags']
        new_lags = profile_params['lags']

--- a/tests/playbooks/mp/test_transport_node_profiles.yml
+++ b/tests/playbooks/mp/test_transport_node_profiles.yml
@@ -19,7 +19,6 @@
         host_switch_spec:
           resource_type: StandardHostSwitchSpec
           host_switches: "{{item.host_switches}}"
-          transport_zone_endpoints: "{{item.transport_zone_endpoints}}"
         state: present
       with_items:
         - "{{transport_node_profiles}}"

--- a/tests/playbooks/mp/test_transport_nodes.yml
+++ b/tests/playbooks/mp/test_transport_nodes.yml
@@ -17,7 +17,6 @@
         host_switch_spec:
           resource_type: StandardHostSwitchSpec
           host_switches: "{{item.host_switches}}"
-        transport_zone_endpoints: "{{item.transport_zone_endpoints}}"
         node_deployment_info: "{{item.node_deployment_info}}"
           # Host node deployment info
           # resource_type: "{{item.node_deployment_info.resource_type}}"
@@ -54,4 +53,4 @@
               #   prefix_length: "{{item.node_deployment_info.deployment_config.vm_deployment_config.management_port_subnets.prefix_length}}"
         state: present
       with_items:
-        - "{{transport_nodes}}"
+        - "{{host_transport_nodes}}"


### PR DESCRIPTION
Description:

Following Bugs were fixed.

BugID     Bug Description
2619445 - nsxt_transport_nodes modules needs updates based on new spec
2648943 - updation of only tags is not supported by 'nsxt_transport_nodes' module
2825054 - Create Edge transport node using ansible module fails
2731783 - Getting "info from vCenter: [SSL: CERTIFICATE_VERIFY_FAILED]" when deploying 2nd and 3rd NSX-T managers
2643929 - "tags" field is not support by "nsxt_transport_node_profiles" module
2645685 - "tags" field is not supported by "nsxt_transport_node_collections" module
2645684 - Updating 'Description' and 'Transport Node Profile' fields in "nsxt_transport_node_collections" module fails
2619365 - nsxt_transport_node_profiles.py fails if transport_zone_endpiont is not provided outside of host_switches
2632169 - [Ansible]deletion of all 'lags' and creation of  'lags' is not supported by 'nsxt_uplink_profiles' ansible module