### PR TITLE
Multiple Bug Fixes.

### DIFF
--- a/plugins/modules/nsxt_upgrade_run.py
+++ b/plugins/modules/nsxt_upgrade_run.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
@@ -72,6 +71,8 @@ def get_upgrade_status(module, manager_url, mgr_username, mgr_password, validate
   '''
   no_of_checks = 0
   while True:
+    endpoint = "/upgrade/upgrade-unit-groups?sync=true"
+    call_get_sync(manager_url, endpoint, mgr_username, mgr_password, validate_certs)
     upgrade_status = get_attribute_from_endpoint(module, manager_url, '/upgrade/status-summary',
                      mgr_username, mgr_password, validate_certs, 'overall_upgrade_status', 
                      False)
@@ -86,7 +87,13 @@ def get_upgrade_status(module, manager_url, mgr_username, mgr_password, validate
       return upgrade_status
     time.sleep(20)
 
-def decide_next_step(module, manager_url, mgr_username, mgr_password, 
+
+def call_get_sync(managerUrl, endpoint, mgrUsername, mgrPassword, validateCerts):
+    request(managerUrl + endpoint, method='GET', url_username=mgrUsername, url_password=mgrPassword,
+            validate_certs=validateCerts, ignore_errors=True)
+
+
+def decide_next_step(module, manager_url, mgr_username, mgr_password,
                      validate_certs, can_continue, is_failed):
   '''
   params:

--- a/tests/playbooks/mp/test_logical_routers.yml
+++ b/tests/playbooks/mp/test_logical_routers.yml
@@ -18,3 +18,21 @@
         router_type: "TIER0"
         high_availability_mode: "ACTIVE_ACTIVE"
         state: "present"
+        failover_mode: "NON_PREEMPTIVE"
+        advanced_config:
+          internal_transit_network: "169.254.0.0/28"
+          ha_vip_configs:
+            - enabled: False
+              ha_vip_subnets:
+                - active_vip_addresses: [ "12.12.4.4" ]
+                  prefix_length: "22"
+              redundant_uplink_port_ids: [ "Uplink-1","Uplink-2" ]
+            - enabled: False
+              ha_vip_subnets:
+                - active_vip_addresses: [ "12.12.4.5" ]
+                  prefix_length: "22"
+              redundant_uplink_port_names: [ "Uplink-3","Uplink-4" ]
+              redundant_uplink_port_ids: ["z", "y"]
+        tags:
+          - scope: "Scope1"
+            tag: "Tag1"


### PR DESCRIPTION
Description:

The following bugs were fixed in this commit.

2654045 - Updation of certain fields are not supported by 'nsxt_logical_routers' module
2687520 - upgrade module 'nsxt_upgrade_run' gets stuck even after MP upgrade completion is 100 percent. and edge upgrade status is cleared from from 100% to 0.0
2634460 - ID should be replace with name for "redundant_uplink_port_ids" under "ha_vip_configs" in "nsxt_logical_routers" module