### PR TITLE
Transport Zone Endpoints is not supported outside Host Switch Spec.

### DIFF
--- a/tests/playbooks/mp/test_transport_nodes.yml
+++ b/tests/playbooks/mp/test_transport_nodes.yml
@@ -17,7 +17,6 @@
         host_switch_spec:
           resource_type: StandardHostSwitchSpec
           host_switches: "{{item.host_switches}}"
-        transport_zone_endpoints: "{{item.transport_zone_endpoints}}"
         node_deployment_info: "{{item.node_deployment_info}}"
           # Host node deployment info
           # resource_type: "{{item.node_deployment_info.resource_type}}"


### PR DESCRIPTION
"transport_zone_endpoints" is not supported outside "host_switch_spec" now. 
Adding the fix.