### PR TITLE
Fix for nsxt_edge_clusters throws error if existing cluster and new cluster are different.

### DIFF
--- a/plugins/module_utils/vcenter_utils.py
+++ b/plugins/module_utils/vcenter_utils.py
@@ -15,7 +15,10 @@ import ssl
 import requests
 import atexit
 
-from pyvim import connect
+try:
+    from pyvim import connect
+except:
+    from pyVim import connect
 from pyVmomi import vmodl
 from pyVmomi import vim
 

--- a/plugins/modules/nsxt_edge_clusters.py
+++ b/plugins/modules/nsxt_edge_clusters.py
@@ -194,7 +194,6 @@ def check_for_update(module, manager_url, mgr_username, mgr_password, validate_c
             return True
         for count, member in enumerate(existing_edge_cluster['members']):
             if member['transport_node_id'] != edge_cluster_with_id['members'][count]['transport_node_id']:
-                module.fail_json(msg='Existing [%s] new [%s]' % (member['transport_node_id'], edge_cluster_with_id['members'][count]['transport_node_id']))
                 return True
     return False
 


### PR DESCRIPTION
Fix for nsxt_edge_clusters throws error if existing cluster and new cluster are different.

Enhancement made to vcenter_utils.py file.

Following bugs are fixed -
BugID     Description
2923954 - nsxt_edge_clusters module throws "Existing [xxx] new [yyy]" error if cluster members are in unexpected order