### PR TITLE
Modify shebang to use ansible_python_interpreter

### DIFF
--- a/plugins/doc_fragments/vmware_nsxt.py
+++ b/plugins/doc_fragments/vmware_nsxt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2021 VMware, Inc.

--- a/plugins/module_utils/common_utils.py
+++ b/plugins/module_utils/common_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright 2019 VMware, Inc.

--- a/plugins/module_utils/nsxt_base_resource.py
+++ b/plugins/module_utils/nsxt_base_resource.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/module_utils/nsxt_resource_urls.py
+++ b/plugins/module_utils/nsxt_resource_urls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 VMware, Inc.

--- a/plugins/module_utils/policy_communicator.py
+++ b/plugins/module_utils/policy_communicator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/module_utils/policy_resource_specs/l2_bridge_ep_profile.py
+++ b/plugins/module_utils/policy_resource_specs/l2_bridge_ep_profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 VMware, Inc.

--- a/plugins/module_utils/policy_resource_specs/security_policy.py
+++ b/plugins/module_utils/policy_resource_specs/security_policy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 VMware, Inc.

--- a/plugins/module_utils/vcenter_utils.py
+++ b/plugins/module_utils/vcenter_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright 2019 VMware, Inc.

--- a/plugins/module_utils/vmware_nsxt.py
+++ b/plugins/module_utils/vmware_nsxt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_certificates.py
+++ b/plugins/modules/nsxt_certificates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_certificates_facts.py
+++ b/plugins/modules/nsxt_certificates_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 VMware, Inc.

--- a/plugins/modules/nsxt_cluster_profiles.py
+++ b/plugins/modules/nsxt_cluster_profiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 VMware, Inc.

--- a/plugins/modules/nsxt_cluster_profiles_facts.py
+++ b/plugins/modules/nsxt_cluster_profiles_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_deploy_ova.py
+++ b/plugins/modules/nsxt_deploy_ova.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_edge_clusters.py
+++ b/plugins/modules/nsxt_edge_clusters.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_edge_clusters_facts.py
+++ b/plugins/modules/nsxt_edge_clusters_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_fabric_compute_managers.py
+++ b/plugins/modules/nsxt_fabric_compute_managers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_fabric_compute_managers_facts.py
+++ b/plugins/modules/nsxt_fabric_compute_managers_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_global_manager_active.py
+++ b/plugins/modules/nsxt_global_manager_active.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2021 VMware, Inc.

--- a/plugins/modules/nsxt_global_manager_enable_service.py
+++ b/plugins/modules/nsxt_global_manager_enable_service.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2021 VMware, Inc.

--- a/plugins/modules/nsxt_global_manager_registration.py
+++ b/plugins/modules/nsxt_global_manager_registration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2021 VMware, Inc.

--- a/plugins/modules/nsxt_ip_blocks.py
+++ b/plugins/modules/nsxt_ip_blocks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_ip_blocks_facts.py
+++ b/plugins/modules/nsxt_ip_blocks_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_ip_pools.py
+++ b/plugins/modules/nsxt_ip_pools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_ip_pools_facts.py
+++ b/plugins/modules/nsxt_ip_pools_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_licenses.py
+++ b/plugins/modules/nsxt_licenses.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_licenses_facts.py
+++ b/plugins/modules/nsxt_licenses_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_local_manager_registration.py
+++ b/plugins/modules/nsxt_local_manager_registration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2021 VMware, Inc.

--- a/plugins/modules/nsxt_local_managers_compatibility.py
+++ b/plugins/modules/nsxt_local_managers_compatibility.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2021 VMware, Inc.

--- a/plugins/modules/nsxt_local_managers_facts.py
+++ b/plugins/modules/nsxt_local_managers_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # Copyright 2021 VMware, Inc.
 # SPDX-License-Identifier: BSD-2-Clause OR GPL-3.0-only

--- a/plugins/modules/nsxt_logical_ports.py
+++ b/plugins/modules/nsxt_logical_ports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_logical_ports_facts.py
+++ b/plugins/modules/nsxt_logical_ports_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_logical_router_ports.py
+++ b/plugins/modules/nsxt_logical_router_ports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_logical_router_ports_facts.py
+++ b/plugins/modules/nsxt_logical_router_ports_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_logical_router_static_routes.py
+++ b/plugins/modules/nsxt_logical_router_static_routes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_logical_routers.py
+++ b/plugins/modules/nsxt_logical_routers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_logical_routers_facts.py
+++ b/plugins/modules/nsxt_logical_routers_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_logical_switches.py
+++ b/plugins/modules/nsxt_logical_switches.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_logical_switches_facts.py
+++ b/plugins/modules/nsxt_logical_switches_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_manager_auto_deployment.py
+++ b/plugins/modules/nsxt_manager_auto_deployment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_manager_auto_deployment_facts.py
+++ b/plugins/modules/nsxt_manager_auto_deployment_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_manager_status.py
+++ b/plugins/modules/nsxt_manager_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_policy_bfd_profile.py
+++ b/plugins/modules/nsxt_policy_bfd_profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 VMware, Inc.

--- a/plugins/modules/nsxt_policy_gateway_policy.py
+++ b/plugins/modules/nsxt_policy_gateway_policy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 VMware, Inc.

--- a/plugins/modules/nsxt_policy_group.py
+++ b/plugins/modules/nsxt_policy_group.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_policy_ip_block.py
+++ b/plugins/modules/nsxt_policy_ip_block.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_policy_ip_pool.py
+++ b/plugins/modules/nsxt_policy_ip_pool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_policy_l2_bridge_ep_profile.py
+++ b/plugins/modules/nsxt_policy_l2_bridge_ep_profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 VMware, Inc.

--- a/plugins/modules/nsxt_policy_security_policy.py
+++ b/plugins/modules/nsxt_policy_security_policy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_policy_segment.py
+++ b/plugins/modules/nsxt_policy_segment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_policy_tier0.py
+++ b/plugins/modules/nsxt_policy_tier0.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_policy_tier1.py
+++ b/plugins/modules/nsxt_policy_tier1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_principal_identities.py
+++ b/plugins/modules/nsxt_principal_identities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_principal_identities_facts.py
+++ b/plugins/modules/nsxt_principal_identities_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_repo_sync.py
+++ b/plugins/modules/nsxt_repo_sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_repo_sync_facts.py
+++ b/plugins/modules/nsxt_repo_sync_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_route_advertise.py
+++ b/plugins/modules/nsxt_route_advertise.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_transport_node_collections.py
+++ b/plugins/modules/nsxt_transport_node_collections.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_transport_node_collections_facts.py
+++ b/plugins/modules/nsxt_transport_node_collections_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_transport_node_profiles.py
+++ b/plugins/modules/nsxt_transport_node_profiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_transport_node_profiles_facts.py
+++ b/plugins/modules/nsxt_transport_node_profiles_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_transport_nodes.py
+++ b/plugins/modules/nsxt_transport_nodes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_transport_nodes_facts.py
+++ b/plugins/modules/nsxt_transport_nodes_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_transport_zones.py
+++ b/plugins/modules/nsxt_transport_zones.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_transport_zones_facts.py
+++ b/plugins/modules/nsxt_transport_zones_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_eula_accept.py
+++ b/plugins/modules/nsxt_upgrade_eula_accept.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_eula_accept_facts.py
+++ b/plugins/modules/nsxt_upgrade_eula_accept_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_groups.py
+++ b/plugins/modules/nsxt_upgrade_groups.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_groups_facts.py
+++ b/plugins/modules/nsxt_upgrade_groups_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_history.py
+++ b/plugins/modules/nsxt_upgrade_history.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_plan.py
+++ b/plugins/modules/nsxt_upgrade_plan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_plan_facts.py
+++ b/plugins/modules/nsxt_upgrade_plan_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_postchecks.py
+++ b/plugins/modules/nsxt_upgrade_postchecks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_pre_post_checks_facts.py
+++ b/plugins/modules/nsxt_upgrade_pre_post_checks_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_prechecks.py
+++ b/plugins/modules/nsxt_upgrade_prechecks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_run.py
+++ b/plugins/modules/nsxt_upgrade_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_status_summary_facts.py
+++ b/plugins/modules/nsxt_upgrade_status_summary_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_uc.py
+++ b/plugins/modules/nsxt_upgrade_uc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_uc_facts.py
+++ b/plugins/modules/nsxt_upgrade_uc_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_upload_mub.py
+++ b/plugins/modules/nsxt_upgrade_upload_mub.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_upgrade_upload_mub_facts.py
+++ b/plugins/modules/nsxt_upgrade_upload_mub_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_uplink_profiles.py
+++ b/plugins/modules/nsxt_uplink_profiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_uplink_profiles_facts.py
+++ b/plugins/modules/nsxt_uplink_profiles_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/plugins/modules/nsxt_vidm.py
+++ b/plugins/modules/nsxt_vidm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2021 VMware, Inc.

--- a/plugins/modules/nsxt_virtual_ip.py
+++ b/plugins/modules/nsxt_virtual_ip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_virtual_ip_facts.py
+++ b/plugins/modules/nsxt_virtual_ip_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2019 VMware, Inc.

--- a/plugins/modules/nsxt_vm_tags.py
+++ b/plugins/modules/nsxt_vm_tags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020 VMware, Inc.

--- a/tests/unit/plugins/module_utils/test_nsxt_base_resource.py
+++ b/tests/unit/plugins/module_utils/test_nsxt_base_resource.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.

--- a/tests/unit/plugins/module_utils/test_policy_communicator.py
+++ b/tests/unit/plugins/module_utils/test_policy_communicator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright 2018 VMware, Inc.


### PR DESCRIPTION
The `vmware.ansible-for-nsxt` module currently breaks ansible module convention by using the `env` shebang.
```shell
#!/usr/bin/env python
```
From the [Ansible Docs](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#python-shebang-utf-8-coding):

> Using `#!/usr/bin/env`, makes `env` the interpreter and bypasses `ansible_<interpreter>_interpreter` logic.

On machines without a symlink from `python` to `python3`, the current implementation is broken.

With this change, the python interpreter is selected by the `ansible_python_interpreter`.


See:
- https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#python-shebang-utf-8-coding
- https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html#interpreter-discovery