### PR TITLE
V3.2.1 Patch / Update NSX-T Rest Python code to make it works (but not idempotent) with NSX-T when _revision is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Documentation on the NSX platform can be found at the [NSX-T Documentation page]
 
 The following versions of NSX are supported:
 
+ * NSX-T 3.2
  * NSX-T 3.1
  * NSX-T 3.0
  * NSX-T 2.5.1
@@ -37,9 +38,14 @@ Using Ansible-for-nsxt requires the following packages to be installated. Instal
 ansible-for-nsxt modules are distributed as Ansible Galaxy collection. Please use the following command to install it
 
 ```
-ansible-galaxy collection install vmware.ansible_for_nsxt
+ansible-galaxy collection install git+https://github.com/vmware/ansible-for-nsxt
 ```
 
+Specify latest supported release branch
+
+```
+ansible-galaxy collection install git+https://github.com/vmware/ansible-for-nsxt.git,v3.2.0
+```
 
 ## Usage
 
@@ -70,6 +76,7 @@ MP API modules can be used to configure an NSX resource with one-to-one mapping.
 ### Branch Information
 This repository has different branches with each branch providing support for upto a specific NSX-T release. Below is the list:
 * Master: Latest code, under development
+* v3.2.0: NSX-T 3.2.x and below
 * v3.0.1: NSX-T 3.1.x and below
 * v3.0.0: NSX-T 3.0.x and below
 * v1.1.0: NSX-T 2.4, NSX-T 2.5
@@ -139,6 +146,8 @@ Note that the Policy modules are supported only for NSX-T 3.0 and above.
 7. IP Blocks (nsxt_policy_ip_block)
 8. BFD Profile (nsxt_policy_bfd_profile)
 9. VM Tags (nsxt_vm_tags)
+10. Gateway Policy (nsxt_policy_gateway_policy)
+11. L2 Bridge Endpoint Profile (nsxt_policy_l2_bridge_ep_profile)
 
 Note that to add a new modules in Policy API, it's base class name should be added in the BASE_RESOURCES in module_utils/nsxt_base_resource.py
 
@@ -284,6 +293,7 @@ Please open a Pull-Request against the Master branch.
 # Support
 
 Released NSX-T Ansible modules are fully supported by VMware. The released modules are available in the specific numbered release branches:
+* v3.2.0
 * v3.0.1
 * v3.0.0
 * v1.1.0

--- a/plugins/modules/nsxt_rest.py
+++ b/plugins/modules/nsxt_rest.py
@@ -218,19 +218,27 @@ class VMwareNSXTRest():
 
         if self.method == "post" or self.method == "put" or self.method == "patch":
             before_resp = self.operate_nsxt(method="get", ignore_errors=True)
-            if before_resp:
+            before_revision = ""
+
+            if before_resp and "_revision" in before_resp :
                 before_revision = before_resp["_revision"]
-            else:
-                before_revision = ""
 
             _ = self.operate_nsxt(method=self.method)
 
             after_resp = self.operate_nsxt(method="get")
-            after_revision = after_resp["_revision"]
+            after_revision = ""
 
-            if before_revision == after_revision:
-                self.module.exit_json(changed=False, body=after_resp)
+            if after_resp and "_revision" in after_resp :
+                after_revision = after_resp["_revision"]
+
+                if before_revision == after_revision:
+                    self.module.exit_json(changed=False, body=after_resp)
+                else:
+                    self.module.exit_json(changed=True, body=after_resp)
+
             else:
+                self.module.warn("_revision key in dict is missing")
+                self.module.warn("Count change but possibly nothing change. Cause : _revision key in dict is missing.")
                 self.module.exit_json(changed=True, body=after_resp)
 
         if self.method == "delete":


### PR DESCRIPTION
Hello,

Du to "_revision" param, I suggest to edit the way to use it like this.
In this version, if NSX-T has not "_revision" param, the ansible module works. It's just not idempotent.
Works on NSX-T 3.1.3 (VCF 4.4.x)

Regards