### PR TITLE
Update nsxt_policy_tier0.py

### DIFF
--- a/plugins/modules/nsxt_policy_tier0.py
+++ b/plugins/modules/nsxt_policy_tier0.py
@@ -917,7 +917,7 @@ options:
                                              255
                                 type: int
                                 default: 1
-                            address:
+                            neighbor_address:
                                 description: Neighbor IP Address
                                 type: str
                                 required: True
@@ -1207,7 +1207,7 @@ EXAMPLES = '''
               summary_only: False
           neighbors:
             - display_name: neigh1
-              address: "1.2.3.4"
+              neighbor_address: "1.2.3.4"
               remote_as_num: "12"
               state: present
         interfaces:


### PR DESCRIPTION
Examples were showing address instead of neighbor_address, causing issues when implementing a playbook with the address variable instead of neighbor_address.