### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyvmomi
+pyvim
+requests


### PR DESCRIPTION
Overview:
Best practice to note python requirements in `requirements.txt` within root of repo for Ansible Collections. The `ssl` package is part of Python standard library. The `ssl` python package is being omitted from `requirements.txt` as it it provides error on install on some systems.

Files Added:
`requirements.txt`

References:
- Per Ansible documentation, a collection is expected to document the necessary python libraries within `requirements.txt` in the root of the collection. See [https://ansible.readthedocs.io/projects/builder/en/stable/collection_metadata/#collection-level-metadata](https://ansible.readthedocs.io/projects/builder/en/stable/collection_metadata/#collection-level-metadata)