### PR TITLE
Bug fix for remove_tags_with_scope feature

### DIFF
--- a/plugins/modules/nsxt_vm_tags.py
+++ b/plugins/modules/nsxt_vm_tags.py
@@ -257,7 +257,7 @@ def realize():
                 scope_list=_read_tags_from_module_params(
                     module.params, 'remove_tags_with_scope'))
             for i, tag in enumerate(all_tags):
-                if TagElement(tag) in tags_to_remove:
+                if TagElement(tag).scope in [ex_tag.scope for ex_tag in tags_to_remove]:
                     all_tags[i] = None
 
         final_tags = [tag for tag in all_tags if tag is not None]


### PR DESCRIPTION
The remove_tags_with_scope option for the nsxt_vm_tags.py module is not functioning as it should.
I believe that the scope value for all tags should be compared to the scope list that is provided in the remove_tags_with_scope option.
I would like to propose the changes to this module. Please review and merge accordingly.
