### PR TITLE
fix: #499 - Permissions required to run nsxt_vm_tags module

### DIFF
--- a/plugins/module_utils/nsxt_resource_urls.py
+++ b/plugins/module_utils/nsxt_resource_urls.py
@@ -61,7 +61,7 @@ EDGE_CLUSTER_URL = _ENFORCEMENT_POINT_URL + '/{}/edge-clusters'
 EDGE_NODE_URL = EDGE_CLUSTER_URL + '/{}/edge-nodes'
 
 VM_LIST_URL = '/virtual-machines'
-VM_UPDATE_URL = '/virtual-machines'
+VM_UPDATE_URL = '/infra/realized-state/virtual-machines'
 
 BFD_PROFILE_URL = '/infra/bfd-profiles'
 

--- a/plugins/modules/nsxt_vm_tags.py
+++ b/plugins/modules/nsxt_vm_tags.py
@@ -272,12 +272,12 @@ def realize():
             module.exit_json(msg="No tags detected to update")
 
         post_body = {
-            "external_id": virtual_machine_id,
             "tags": final_tags
         }
         policy_communicator.request(
-            VM_UPDATE_URL + '?action=update_tags', data=post_body,
-            method="POST", base_url='fabric')
+            VM_UPDATE_URL + '/' + virtual_machine_id + '/tags', data=post_body,
+            method="POST", base_url='policy')
+
         module.exit_json(msg="Successfully updated tags on VM {}".format(
             virtual_machine_id), changed=True)
     except Exception as err:


### PR DESCRIPTION
This fix allows the module to apply changes on vm tags with limited permissions granted

The playbook can be run with a principal identity or a local user member of a role with the minimal permissions:
- read-only "Virtual Machines"
- full-access on "Tags"

