### PR TITLE
update regex for bpo-27364

### DIFF
--- a/plugins/module_utils/vmware_nsxt.py
+++ b/plugins/module_utils/vmware_nsxt.py
@@ -154,10 +154,10 @@ def get_private_key_string(p12_file):
     certificate_string = ""
     got_start_line = False
     for string in file_content:
-        if re.match("-+BEGIN[ \w]+PRIVATE[ ]+KEY-+", string):
+        if re.match("-+BEGIN[ A-Z0-9]+PRIVATE[ ]+KEY-+", string):
             got_start_line = True
             certificate_string = certificate_string + string + "\n"
-        elif re.match("-+END[ \w]+PRIVATE[ ]+KEY-+", string):
+        elif re.match("-+END[ A-Z0-9]+PRIVATE[ ]+KEY-+", string):
             certificate_string = certificate_string + "\n" + string
             break
         elif got_start_line:


### PR DESCRIPTION
Update regex to remove `<unknown>:157: SyntaxWarning: invalid escape sequence '\w'` warnings when using Python 3.12.