### PR TITLE
Add vmFolder option to deploy_ova module

### DIFF
--- a/plugins/modules/nsxt_deploy_ova.py
+++ b/plugins/modules/nsxt_deploy_ova.py
@@ -321,6 +321,9 @@ def main():
     ovf_deployement_size = ['--deploymentOption={}'.format(module.params['deployment_size'])]
     ovf_command.extend(ovf_deployement_size)
 
+    if module.params['folder']:
+        ovf_command.extend(['--vmFolder'.format(module.params['folder'])])
+
     ovf_ext_prop = ['--prop:nsx_hostname={}'.format(module.params['hostname']),
                     '--prop:nsx_dns1_0={}'.format(module.params['dns_server']),
                     '--prop:nsx_domain_0={}'.format(module.params['dns_domain']),
@@ -352,8 +355,6 @@ def main():
 
     vi_string = 'vi://{}:{}@{}/'.format(module.params['vcenter_user'],
                                         module.params['vcenter_passwd'], module.params['vcenter'])
-    if module.params.__contains__('folder') and module.params['folder']:
-        vi_string = vi_string + module.params['folder']
 
     vi_string = vi_string + '/{}/host/{}/'.format(module.params['datacenter'], module.params['cluster'])
 


### PR DESCRIPTION
## Description
This merge request introduces a new option, `vmFolder`, to the `deploy_ova` module. The addition allows users to specify a folder within the ESX cluster where the desired VM should be created.
The already used `folder` parameter is leveraged. When the user specifies it, the OVFTool parameter `--vmFolder` is added to the `ovf_base_options` array.

## Changes Made
- Added a check for the `folder` parameter in the `deploy_ova` module.
- Extended the `ovf_command` with the `--vmFolder` option if the `folder` parameter is provided.
- Removed the previous logic that appended the folder to the `vi_string`. This seemed to be a bug. It didn't work if the parameter was specified.

## Testing
- Verified that the `deploy_ova` module correctly includes the `--vmFolder` option when the `folder` parameter is specified.
- Ensured that the module functions as expected without the `folder` parameter.

Thank you for considering this merge request. Please let me know if there are any questions or further improvements needed.
