### PR TITLE
Check NSX version to detect MP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .DS_Store
 # test output
 *.retry
+# JetBrains project dir
+.idea

--- a/plugins/modules/nsxt_logical_switches.py
+++ b/plugins/modules/nsxt_logical_switches.py
@@ -186,7 +186,7 @@ RETURN = '''# '''
 
 import json, time
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.vmware.ansible_for_nsxt.plugins.module_utils.vmware_nsxt import vmware_argument_spec, request
+from ansible_collections.vmware.ansible_for_nsxt.plugins.module_utils.vmware_nsxt import vmware_argument_spec, request, validate_nsx_mp_support
 from ansible.module_utils._text import to_native
 
 def get_logical_switch_params(args=None):
@@ -309,6 +309,8 @@ def main():
   validate_certs = module.params['validate_certs']
   display_name = module.params['display_name']
   manager_url = 'https://{}/api/v1'.format(mgr_hostname)
+
+  validate_nsx_mp_support(module, manager_url, mgr_username, mgr_password, validate_certs)
 
   changed = True
   lswitch_dict = get_lswitch_from_display_name (module, manager_url, mgr_username, mgr_password, validate_certs, display_name)


### PR DESCRIPTION
MP support has been deprecated in NSX v9.x, so validate that NSX is running below this version on logical switch MP.